### PR TITLE
Added ability to schedule a scan to run periodically on a cluster

### DIFF
--- a/crds/scheduledscan.yaml
+++ b/crds/scheduledscan.yaml
@@ -3,6 +3,16 @@ kind: CustomResourceDefinition
 metadata:
   name: scheduledscans.cis.cattle.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.lastRunTimestamp
+    name: LastRunTimestamp
+    type: string
+  - JSONPath: .status.lastClusterScanName
+    name: LastClusterScanName
+    type: string
+  - JSONPath: .spec.cronSchedule
+    name: CronSchedule
+    type: string
   group: cis.cattle.io
   names:
     kind: ScheduledScan
@@ -16,37 +26,48 @@ spec:
         spec:
           properties:
             cronSchedule:
+              nullable: true
               type: string
             retentionCount:
               type: integer
             scanProfileName:
+              nullable: true
               type: string
           type: object
         status:
           properties:
+            NextScanAt:
+              nullable: true
+              type: string
             conditions:
               items:
                 properties:
                   lastTransitionTime:
+                    nullable: true
                     type: string
                   lastUpdateTime:
+                    nullable: true
                     type: string
                   message:
+                    nullable: true
                     type: string
                   reason:
+                    nullable: true
                     type: string
                   status:
+                    nullable: true
                     type: string
                   type:
+                    nullable: true
                     type: string
                 type: object
               nullable: true
               type: array
-            enabled:
-              type: boolean
             lastClusterScanName:
+              nullable: true
               type: string
             lastRunTimestamp:
+              nullable: true
               type: string
             observedGeneration:
               type: integer

--- a/examples/ssrkehardened.yml
+++ b/examples/ssrkehardened.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ScheduledScan
+metadata:
+  name: ss-rke-cis-hard
+spec:
+  scanProfileName: rke-profile-hardened
+  cronSchedule: "*/2 * * * *"
+  retentionCount: 3

--- a/examples/ssrkeperm.yml
+++ b/examples/ssrkeperm.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ScheduledScan
+metadata:
+  name: ss-rke-cis-perm
+spec:
+  scanProfileName: rke-profile-permissive
+  cronSchedule: "*/5 * * * *"
+  retentionCount: 3

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0
 	github.com/rancher/security-scan v0.2.1
 	github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224
+	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/urfave/cli v1.22.2
 	k8s.io/api v0.18.8

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,8 @@ github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224 h1:NWYSyS1YiWJO
 github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/pkg/apis/cis.cattle.io/v1/types.go
+++ b/pkg/apis/cis.cattle.io/v1/types.go
@@ -22,6 +22,8 @@ const (
 	DefaultClusterScanProfileConfigMap = "default-clusterscanprofiles"
 	ClusterScanService                 = "service-rancher-cis-benchmark"
 	DefaultScanOutputFileName          = "output.json"
+	DefaultRetention                   = 3
+	DefaultCronSchedule                = "0 0 * * *"
 
 	ClusterScanConditionCreated      = condition.Cond("Created")
 	ClusterScanConditionPending      = condition.Cond("Pending")
@@ -149,9 +151,9 @@ type ScheduledScanSpec struct {
 }
 
 type ScheduledScanStatus struct {
-	Enabled             bool                                `yaml:"enabled" json:"enabled,omitempty"`
 	LastRunTimestamp    string                              `yaml:"last_run_timestamp" json:"lastRunTimestamp"`
-	LastClusterScanName string                              `yaml:"last_cis_name" json:"lastClusterScanName"`
+	LastClusterScanName string                              `yaml:"last_cluster_scan_name" json:"lastClusterScanName"`
+	NextScanAt          string                              `json:"NextScanAt"`
 	ObservedGeneration  int64                               `json:"observedGeneration"`
 	Conditions          []genericcondition.GenericCondition `json:"conditions,omitempty"`
 }

--- a/pkg/crds/crd.go
+++ b/pkg/crds/crd.go
@@ -59,6 +59,12 @@ func List() []crd.CRD {
 				WithColumn("MinKubernetesVersion", ".spec.minKubernetesVersion").
 				WithColumn("MaxKubernetesVersion", ".spec.maxKubernetesVersion")
 		}),
+		newCRD(&cisoperator.ScheduledScan{}, func(c crd.CRD) crd.CRD {
+			return c.
+				WithColumn("LastRunTimestamp", ".status.lastRunTimestamp").
+				WithColumn("LastClusterScanName", ".status.lastClusterScanName").
+				WithColumn("CronSchedule", ".spec.cronSchedule")
+		}),
 	}
 }
 

--- a/pkg/securityscan/controller.go
+++ b/pkg/securityscan/controller.go
@@ -114,6 +114,9 @@ func (c *Controller) Start(ctx context.Context, threads int, resync time.Duratio
 	if err := c.handleClusterScans(ctx); err != nil {
 		return err
 	}
+	if err := c.handleScheduledScans(ctx); err != nil {
+		return err
+	}
 
 	return start.All(ctx, threads, c.cisFactory, c.coreFactory, c.batchFactory)
 }

--- a/pkg/securityscan/scheduledScanHandler.go
+++ b/pkg/securityscan/scheduledScanHandler.go
@@ -1,0 +1,196 @@
+package securityscan
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	v1 "github.com/rancher/cis-operator/pkg/apis/cis.cattle.io/v1"
+	"github.com/rancher/wrangler/pkg/genericcondition"
+	"github.com/rancher/wrangler/pkg/name"
+	"github.com/robfig/cron"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/retry"
+)
+
+func (c *Controller) handleScheduledScans(ctx context.Context) error {
+	scheduledScans := c.cisFactory.Cis().V1().ScheduledScan()
+	scans := c.cisFactory.Cis().V1().ClusterScan()
+
+	scheduledScans.OnChange(ctx, c.Name, func(key string, obj *v1.ScheduledScan) (*v1.ScheduledScan, error) {
+		if obj == nil || obj.DeletionTimestamp != nil {
+			return obj, nil
+		}
+
+		logrus.Infof("scheduledScanHandler: sync called for scheduledScan CR %v ", obj.Name)
+
+		if err := c.validateScheduledScanSpec(obj); err != nil {
+			v1.ClusterScanConditionFailed.True(obj)
+			message := fmt.Sprintf("Error validating Schedule %v, error: %v", obj.Spec.CronSchedule, err)
+			v1.ClusterScanConditionFailed.Message(obj, message)
+			logrus.Errorf(message)
+			return scheduledScans.UpdateStatus(obj)
+		}
+
+		//if nextScanAt is set then make sure we process only if the time is right
+		if obj.Status.LastRunTimestamp != "" && obj.Status.NextScanAt != "" {
+			currTime := time.Now().Format(time.RFC3339)
+			logrus.Infof("scheduledScanHandler: next scan is scheduled for: %v, current time: %v", obj.Status.NextScanAt, currTime)
+
+			nextScanTime, err := time.Parse(time.RFC3339, obj.Status.NextScanAt)
+			if err != nil {
+				return obj, fmt.Errorf("scheduledScanHandler: retrying, got error %v in parsing NextScanAt %v time for scheduledScan: %v ", err, obj.Status.NextScanAt, obj.Name)
+			}
+			if nextScanTime.After(time.Now()) {
+				logrus.Infof("scheduledScanHandler: run time is later, skipping this run scheduledScan CR %v ", obj.Name)
+				after := nextScanTime.Sub(time.Now())
+				scheduledScans.EnqueueAfter(obj.Name, after)
+				if obj.Generation != obj.Status.ObservedGeneration {
+					obj.Status.ObservedGeneration = obj.Generation
+					return scheduledScans.UpdateStatus(obj)
+				}
+				return obj, nil
+			}
+		}
+
+		logrus.Infof("scheduledScanHandler: processing scheduledScan CR %v ", obj.Name)
+
+		schedule := c.getCronSchedule(obj)
+		cronSchedule, err := cron.ParseStandard(schedule)
+		if err != nil {
+			return obj, fmt.Errorf("Error parsing invalid cron string for schedule: %v", err)
+		}
+
+		clusterScan := c.createClusterScan(obj)
+		logrus.Infof("scheduledScanHandler: creating new clusterScan CR %v ", clusterScan.GenerateName)
+		createdClusterScan, err := scans.Create(clusterScan)
+		if err != nil {
+			return nil, fmt.Errorf("Error %v saving clusterscan object", err)
+		}
+
+		updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var err error
+			scheduledScanObj, err := scheduledScans.Get(obj.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			// reset conditions to remove the reconciling condition, because as per kstatus lib its presence is considered an error
+			scheduledScanObj.Status.Conditions = []genericcondition.GenericCondition{}
+			now := time.Now()
+			scheduledScanObj.Status.LastRunTimestamp = now.Format(time.RFC3339)
+			scheduledScanObj.Status.LastClusterScanName = createdClusterScan.Name
+
+			nextScanAt := cronSchedule.Next(now)
+			scheduledScanObj.Status.NextScanAt = nextScanAt.Format(time.RFC3339)
+			after := nextScanAt.Sub(now)
+			scheduledScans.EnqueueAfter(scheduledScanObj.Name, after)
+
+			scheduledScanObj.Status.ObservedGeneration = scheduledScanObj.Generation
+			_, err = scheduledScans.UpdateStatus(scheduledScanObj)
+			return err
+		})
+
+		if updateErr != nil {
+			return obj, fmt.Errorf("Retrying, got error %v in updating status for scheduledScan: %v ", err, obj.Name)
+		}
+
+		if err := c.purgeOldClusterScans(obj); err != nil {
+			return obj, err
+		}
+
+		return obj, nil
+	})
+
+	return nil
+}
+
+func (c *Controller) validateScheduledScanSpec(obj *v1.ScheduledScan) error {
+	if obj.Spec.CronSchedule != "" {
+		_, err := cron.ParseStandard(obj.Spec.CronSchedule)
+		if err != nil {
+			return fmt.Errorf("error parsing invalid cron string for schedule: %v", err)
+		}
+	}
+	return nil
+}
+
+func (c *Controller) getCronSchedule(obj *v1.ScheduledScan) string {
+	cronSchedule := v1.DefaultCronSchedule
+	if obj.Spec.CronSchedule != "" {
+		cronSchedule = obj.Spec.CronSchedule
+	}
+	return cronSchedule
+}
+
+func (c *Controller) getRetentionCount(obj *v1.ScheduledScan) int {
+	retentionCount := v1.DefaultRetention
+	if obj.Spec.RetentionCount != 0 {
+		retentionCount = obj.Spec.RetentionCount
+	}
+	return retentionCount
+}
+
+func (c *Controller) createClusterScan(scheduleScan *v1.ScheduledScan) *v1.ClusterScan {
+	clusterScan := &v1.ClusterScan{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: name.SafeConcatName("ss", scheduleScan.Name) + "-",
+		},
+		Spec: v1.ClusterScanSpec{
+			ScanProfileName: scheduleScan.Spec.ScanProfileName,
+		},
+	}
+	ownerRef := metav1.OwnerReference{
+		APIVersion: "cis.cattle.io/v1",
+		Kind:       "ScheduledScan",
+		Name:       scheduleScan.Name,
+		UID:        scheduleScan.GetUID(),
+	}
+	clusterScan.ObjectMeta.OwnerReferences = append(clusterScan.ObjectMeta.OwnerReferences, ownerRef)
+
+	return clusterScan
+}
+
+func (c *Controller) purgeOldClusterScans(scheduleScan *v1.ScheduledScan) error {
+	scans := c.cisFactory.Cis().V1().ClusterScan()
+	retention := c.getRetentionCount(scheduleScan)
+	logrus.Infof("scheduledScanHandler: purgeOldScans for scheduledScan: %v ,retention: %v", scheduleScan.Name, retention)
+	allClusterScans, err := scans.Cache().List(labels.NewSelector())
+	if err != nil {
+		return fmt.Errorf("error listing cluster scans for scheduledScan %v: %v", scheduleScan.Name, err)
+	}
+	var clusterScans []*v1.ClusterScan
+	for _, cs := range allClusterScans {
+		if !strings.HasPrefix(cs.Name, name.SafeConcatName("ss", scheduleScan.Name)+"-") {
+			continue
+		}
+		clusterScans = append(clusterScans, cs)
+	}
+	if len(clusterScans) <= retention {
+		return nil
+	}
+	sort.Slice(clusterScans, func(i, j int) bool {
+		return !clusterScans[i].CreationTimestamp.Before(&clusterScans[j].CreationTimestamp)
+	})
+	for _, cs := range clusterScans[retention:] {
+		logrus.Infof("scheduledScanHandler: purgeOldScans: deleting cs: %v %v", cs.Name, cs.CreationTimestamp.String())
+		if err := c.deleteClusterScanWithRetry(cs.Name); err != nil {
+			logrus.Errorf("scheduledScanHandler: purgeOldScans: error deleting cluster scan: %v: %v",
+				cs.Name, err)
+		}
+	}
+	return nil
+}
+
+func (c *Controller) deleteClusterScanWithRetry(name string) error {
+	scans := c.cisFactory.Cis().V1().ClusterScan()
+	delErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var err error
+		err = scans.Delete(name, &metav1.DeleteOptions{})
+		return err
+	})
+	return delErr
+}

--- a/vendor/github.com/robfig/cron/.gitignore
+++ b/vendor/github.com/robfig/cron/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/robfig/cron/.travis.yml
+++ b/vendor/github.com/robfig/cron/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/robfig/cron/LICENSE
+++ b/vendor/github.com/robfig/cron/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2012 Rob Figueiredo
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/robfig/cron/README.md
+++ b/vendor/github.com/robfig/cron/README.md
@@ -1,0 +1,6 @@
+[![GoDoc](http://godoc.org/github.com/robfig/cron?status.png)](http://godoc.org/github.com/robfig/cron) 
+[![Build Status](https://travis-ci.org/robfig/cron.svg?branch=master)](https://travis-ci.org/robfig/cron)
+
+# cron
+
+Documentation here: https://godoc.org/github.com/robfig/cron

--- a/vendor/github.com/robfig/cron/constantdelay.go
+++ b/vendor/github.com/robfig/cron/constantdelay.go
@@ -1,0 +1,27 @@
+package cron
+
+import "time"
+
+// ConstantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
+// It does not support jobs more frequent than once a second.
+type ConstantDelaySchedule struct {
+	Delay time.Duration
+}
+
+// Every returns a crontab Schedule that activates once every duration.
+// Delays of less than a second are not supported (will round up to 1 second).
+// Any fields less than a Second are truncated.
+func Every(duration time.Duration) ConstantDelaySchedule {
+	if duration < time.Second {
+		duration = time.Second
+	}
+	return ConstantDelaySchedule{
+		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
+	}
+}
+
+// Next returns the next time this should be run.
+// This rounds so that the next activation time will be on the second.
+func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
+}

--- a/vendor/github.com/robfig/cron/cron.go
+++ b/vendor/github.com/robfig/cron/cron.go
@@ -1,0 +1,259 @@
+package cron
+
+import (
+	"log"
+	"runtime"
+	"sort"
+	"time"
+)
+
+// Cron keeps track of any number of entries, invoking the associated func as
+// specified by the schedule. It may be started, stopped, and the entries may
+// be inspected while running.
+type Cron struct {
+	entries  []*Entry
+	stop     chan struct{}
+	add      chan *Entry
+	snapshot chan []*Entry
+	running  bool
+	ErrorLog *log.Logger
+	location *time.Location
+}
+
+// Job is an interface for submitted cron jobs.
+type Job interface {
+	Run()
+}
+
+// The Schedule describes a job's duty cycle.
+type Schedule interface {
+	// Return the next activation time, later than the given time.
+	// Next is invoked initially, and then each time the job is run.
+	Next(time.Time) time.Time
+}
+
+// Entry consists of a schedule and the func to execute on that schedule.
+type Entry struct {
+	// The schedule on which this job should be run.
+	Schedule Schedule
+
+	// The next time the job will run. This is the zero time if Cron has not been
+	// started or this entry's schedule is unsatisfiable
+	Next time.Time
+
+	// The last time this job was run. This is the zero time if the job has never
+	// been run.
+	Prev time.Time
+
+	// The Job to run.
+	Job Job
+}
+
+// byTime is a wrapper for sorting the entry array by time
+// (with zero time at the end).
+type byTime []*Entry
+
+func (s byTime) Len() int      { return len(s) }
+func (s byTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s byTime) Less(i, j int) bool {
+	// Two zero times should return false.
+	// Otherwise, zero is "greater" than any other time.
+	// (To sort it at the end of the list.)
+	if s[i].Next.IsZero() {
+		return false
+	}
+	if s[j].Next.IsZero() {
+		return true
+	}
+	return s[i].Next.Before(s[j].Next)
+}
+
+// New returns a new Cron job runner, in the Local time zone.
+func New() *Cron {
+	return NewWithLocation(time.Now().Location())
+}
+
+// NewWithLocation returns a new Cron job runner.
+func NewWithLocation(location *time.Location) *Cron {
+	return &Cron{
+		entries:  nil,
+		add:      make(chan *Entry),
+		stop:     make(chan struct{}),
+		snapshot: make(chan []*Entry),
+		running:  false,
+		ErrorLog: nil,
+		location: location,
+	}
+}
+
+// A wrapper that turns a func() into a cron.Job
+type FuncJob func()
+
+func (f FuncJob) Run() { f() }
+
+// AddFunc adds a func to the Cron to be run on the given schedule.
+func (c *Cron) AddFunc(spec string, cmd func()) error {
+	return c.AddJob(spec, FuncJob(cmd))
+}
+
+// AddJob adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) AddJob(spec string, cmd Job) error {
+	schedule, err := Parse(spec)
+	if err != nil {
+		return err
+	}
+	c.Schedule(schedule, cmd)
+	return nil
+}
+
+// Schedule adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) Schedule(schedule Schedule, cmd Job) {
+	entry := &Entry{
+		Schedule: schedule,
+		Job:      cmd,
+	}
+	if !c.running {
+		c.entries = append(c.entries, entry)
+		return
+	}
+
+	c.add <- entry
+}
+
+// Entries returns a snapshot of the cron entries.
+func (c *Cron) Entries() []*Entry {
+	if c.running {
+		c.snapshot <- nil
+		x := <-c.snapshot
+		return x
+	}
+	return c.entrySnapshot()
+}
+
+// Location gets the time zone location
+func (c *Cron) Location() *time.Location {
+	return c.location
+}
+
+// Start the cron scheduler in its own go-routine, or no-op if already started.
+func (c *Cron) Start() {
+	if c.running {
+		return
+	}
+	c.running = true
+	go c.run()
+}
+
+// Run the cron scheduler, or no-op if already running.
+func (c *Cron) Run() {
+	if c.running {
+		return
+	}
+	c.running = true
+	c.run()
+}
+
+func (c *Cron) runWithRecovery(j Job) {
+	defer func() {
+		if r := recover(); r != nil {
+			const size = 64 << 10
+			buf := make([]byte, size)
+			buf = buf[:runtime.Stack(buf, false)]
+			c.logf("cron: panic running job: %v\n%s", r, buf)
+		}
+	}()
+	j.Run()
+}
+
+// Run the scheduler. this is private just due to the need to synchronize
+// access to the 'running' state variable.
+func (c *Cron) run() {
+	// Figure out the next activation times for each entry.
+	now := c.now()
+	for _, entry := range c.entries {
+		entry.Next = entry.Schedule.Next(now)
+	}
+
+	for {
+		// Determine the next entry to run.
+		sort.Sort(byTime(c.entries))
+
+		var timer *time.Timer
+		if len(c.entries) == 0 || c.entries[0].Next.IsZero() {
+			// If there are no entries yet, just sleep - it still handles new entries
+			// and stop requests.
+			timer = time.NewTimer(100000 * time.Hour)
+		} else {
+			timer = time.NewTimer(c.entries[0].Next.Sub(now))
+		}
+
+		for {
+			select {
+			case now = <-timer.C:
+				now = now.In(c.location)
+				// Run every entry whose next time was less than now
+				for _, e := range c.entries {
+					if e.Next.After(now) || e.Next.IsZero() {
+						break
+					}
+					go c.runWithRecovery(e.Job)
+					e.Prev = e.Next
+					e.Next = e.Schedule.Next(now)
+				}
+
+			case newEntry := <-c.add:
+				timer.Stop()
+				now = c.now()
+				newEntry.Next = newEntry.Schedule.Next(now)
+				c.entries = append(c.entries, newEntry)
+
+			case <-c.snapshot:
+				c.snapshot <- c.entrySnapshot()
+				continue
+
+			case <-c.stop:
+				timer.Stop()
+				return
+			}
+
+			break
+		}
+	}
+}
+
+// Logs an error to stderr or to the configured error log
+func (c *Cron) logf(format string, args ...interface{}) {
+	if c.ErrorLog != nil {
+		c.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}
+
+// Stop stops the cron scheduler if it is running; otherwise it does nothing.
+func (c *Cron) Stop() {
+	if !c.running {
+		return
+	}
+	c.stop <- struct{}{}
+	c.running = false
+}
+
+// entrySnapshot returns a copy of the current cron entry list.
+func (c *Cron) entrySnapshot() []*Entry {
+	entries := []*Entry{}
+	for _, e := range c.entries {
+		entries = append(entries, &Entry{
+			Schedule: e.Schedule,
+			Next:     e.Next,
+			Prev:     e.Prev,
+			Job:      e.Job,
+		})
+	}
+	return entries
+}
+
+// now returns current time in c location
+func (c *Cron) now() time.Time {
+	return time.Now().In(c.location)
+}

--- a/vendor/github.com/robfig/cron/doc.go
+++ b/vendor/github.com/robfig/cron/doc.go
@@ -1,0 +1,129 @@
+/*
+Package cron implements a cron spec parser and job runner.
+
+Usage
+
+Callers may register Funcs to be invoked on a given schedule.  Cron will run
+them in their own goroutines.
+
+	c := cron.New()
+	c.AddFunc("0 30 * * * *", func() { fmt.Println("Every hour on the half hour") })
+	c.AddFunc("@hourly",      func() { fmt.Println("Every hour") })
+	c.AddFunc("@every 1h30m", func() { fmt.Println("Every hour thirty") })
+	c.Start()
+	..
+	// Funcs are invoked in their own goroutine, asynchronously.
+	...
+	// Funcs may also be added to a running Cron
+	c.AddFunc("@daily", func() { fmt.Println("Every day") })
+	..
+	// Inspect the cron job entries' next and previous run times.
+	inspect(c.Entries())
+	..
+	c.Stop()  // Stop the scheduler (does not stop any jobs already running).
+
+CRON Expression Format
+
+A cron expression represents a set of times, using 6 space-separated fields.
+
+	Field name   | Mandatory? | Allowed values  | Allowed special characters
+	----------   | ---------- | --------------  | --------------------------
+	Seconds      | Yes        | 0-59            | * / , -
+	Minutes      | Yes        | 0-59            | * / , -
+	Hours        | Yes        | 0-23            | * / , -
+	Day of month | Yes        | 1-31            | * / , - ?
+	Month        | Yes        | 1-12 or JAN-DEC | * / , -
+	Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
+
+Note: Month and Day-of-week field values are case insensitive.  "SUN", "Sun",
+and "sun" are equally accepted.
+
+Special Characters
+
+Asterisk ( * )
+
+The asterisk indicates that the cron expression will match for all values of the
+field; e.g., using an asterisk in the 5th field (month) would indicate every
+month.
+
+Slash ( / )
+
+Slashes are used to describe increments of ranges. For example 3-59/15 in the
+1st field (minutes) would indicate the 3rd minute of the hour and every 15
+minutes thereafter. The form "*\/..." is equivalent to the form "first-last/...",
+that is, an increment over the largest possible range of the field.  The form
+"N/..." is accepted as meaning "N-MAX/...", that is, starting at N, use the
+increment until the end of that specific range.  It does not wrap around.
+
+Comma ( , )
+
+Commas are used to separate items of a list. For example, using "MON,WED,FRI" in
+the 5th field (day of week) would mean Mondays, Wednesdays and Fridays.
+
+Hyphen ( - )
+
+Hyphens are used to define ranges. For example, 9-17 would indicate every
+hour between 9am and 5pm inclusive.
+
+Question mark ( ? )
+
+Question mark may be used instead of '*' for leaving either day-of-month or
+day-of-week blank.
+
+Predefined schedules
+
+You may use one of several pre-defined schedules in place of a cron expression.
+
+	Entry                  | Description                                | Equivalent To
+	-----                  | -----------                                | -------------
+	@yearly (or @annually) | Run once a year, midnight, Jan. 1st        | 0 0 0 1 1 *
+	@monthly               | Run once a month, midnight, first of month | 0 0 0 1 * *
+	@weekly                | Run once a week, midnight between Sat/Sun  | 0 0 0 * * 0
+	@daily (or @midnight)  | Run once a day, midnight                   | 0 0 0 * * *
+	@hourly                | Run once an hour, beginning of hour        | 0 0 * * * *
+
+Intervals
+
+You may also schedule a job to execute at fixed intervals, starting at the time it's added 
+or cron is run. This is supported by formatting the cron spec like this:
+
+    @every <duration>
+
+where "duration" is a string accepted by time.ParseDuration
+(http://golang.org/pkg/time/#ParseDuration).
+
+For example, "@every 1h30m10s" would indicate a schedule that activates after
+1 hour, 30 minutes, 10 seconds, and then every interval after that.
+
+Note: The interval does not take the job runtime into account.  For example,
+if a job takes 3 minutes to run, and it is scheduled to run every 5 minutes,
+it will have only 2 minutes of idle time between each run.
+
+Time zones
+
+All interpretation and scheduling is done in the machine's local time zone (as
+provided by the Go time package (http://www.golang.org/pkg/time).
+
+Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
+not be run!
+
+Thread safety
+
+Since the Cron service runs concurrently with the calling code, some amount of
+care must be taken to ensure proper synchronization.
+
+All cron methods are designed to be correctly synchronized as long as the caller
+ensures that invocations have a clear happens-before ordering between them.
+
+Implementation
+
+Cron entries are stored in an array, sorted by their next activation time.  Cron
+sleeps until the next job is due to be run.
+
+Upon waking:
+ - it runs each entry that is active on that second
+ - it calculates the next run times for the jobs that were run
+ - it re-sorts the array of entries by next activation time.
+ - it goes to sleep until the soonest job.
+*/
+package cron

--- a/vendor/github.com/robfig/cron/parser.go
+++ b/vendor/github.com/robfig/cron/parser.go
@@ -1,0 +1,380 @@
+package cron
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Configuration options for creating a parser. Most options specify which
+// fields should be included, while others enable features. If a field is not
+// included the parser will assume a default value. These options do not change
+// the order fields are parse in.
+type ParseOption int
+
+const (
+	Second      ParseOption = 1 << iota // Seconds field, default 0
+	Minute                              // Minutes field, default 0
+	Hour                                // Hours field, default 0
+	Dom                                 // Day of month field, default *
+	Month                               // Month field, default *
+	Dow                                 // Day of week field, default *
+	DowOptional                         // Optional day of week field, default *
+	Descriptor                          // Allow descriptors such as @monthly, @weekly, etc.
+)
+
+var places = []ParseOption{
+	Second,
+	Minute,
+	Hour,
+	Dom,
+	Month,
+	Dow,
+}
+
+var defaults = []string{
+	"0",
+	"0",
+	"0",
+	"*",
+	"*",
+	"*",
+}
+
+// A custom Parser that can be configured.
+type Parser struct {
+	options   ParseOption
+	optionals int
+}
+
+// Creates a custom Parser with custom options.
+//
+//  // Standard parser without descriptors
+//  specParser := NewParser(Minute | Hour | Dom | Month | Dow)
+//  sched, err := specParser.Parse("0 0 15 */3 *")
+//
+//  // Same as above, just excludes time fields
+//  subsParser := NewParser(Dom | Month | Dow)
+//  sched, err := specParser.Parse("15 */3 *")
+//
+//  // Same as above, just makes Dow optional
+//  subsParser := NewParser(Dom | Month | DowOptional)
+//  sched, err := specParser.Parse("15 */3")
+//
+func NewParser(options ParseOption) Parser {
+	optionals := 0
+	if options&DowOptional > 0 {
+		options |= Dow
+		optionals++
+	}
+	return Parser{options, optionals}
+}
+
+// Parse returns a new crontab schedule representing the given spec.
+// It returns a descriptive error if the spec is not valid.
+// It accepts crontab specs and features configured by NewParser.
+func (p Parser) Parse(spec string) (Schedule, error) {
+	if len(spec) == 0 {
+		return nil, fmt.Errorf("Empty spec string")
+	}
+	if spec[0] == '@' && p.options&Descriptor > 0 {
+		return parseDescriptor(spec)
+	}
+
+	// Figure out how many fields we need
+	max := 0
+	for _, place := range places {
+		if p.options&place > 0 {
+			max++
+		}
+	}
+	min := max - p.optionals
+
+	// Split fields on whitespace
+	fields := strings.Fields(spec)
+
+	// Validate number of fields
+	if count := len(fields); count < min || count > max {
+		if min == max {
+			return nil, fmt.Errorf("Expected exactly %d fields, found %d: %s", min, count, spec)
+		}
+		return nil, fmt.Errorf("Expected %d to %d fields, found %d: %s", min, max, count, spec)
+	}
+
+	// Fill in missing fields
+	fields = expandFields(fields, p.options)
+
+	var err error
+	field := func(field string, r bounds) uint64 {
+		if err != nil {
+			return 0
+		}
+		var bits uint64
+		bits, err = getField(field, r)
+		return bits
+	}
+
+	var (
+		second     = field(fields[0], seconds)
+		minute     = field(fields[1], minutes)
+		hour       = field(fields[2], hours)
+		dayofmonth = field(fields[3], dom)
+		month      = field(fields[4], months)
+		dayofweek  = field(fields[5], dow)
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SpecSchedule{
+		Second: second,
+		Minute: minute,
+		Hour:   hour,
+		Dom:    dayofmonth,
+		Month:  month,
+		Dow:    dayofweek,
+	}, nil
+}
+
+func expandFields(fields []string, options ParseOption) []string {
+	n := 0
+	count := len(fields)
+	expFields := make([]string, len(places))
+	copy(expFields, defaults)
+	for i, place := range places {
+		if options&place > 0 {
+			expFields[i] = fields[n]
+			n++
+		}
+		if n == count {
+			break
+		}
+	}
+	return expFields
+}
+
+var standardParser = NewParser(
+	Minute | Hour | Dom | Month | Dow | Descriptor,
+)
+
+// ParseStandard returns a new crontab schedule representing the given standardSpec
+// (https://en.wikipedia.org/wiki/Cron). It differs from Parse requiring to always
+// pass 5 entries representing: minute, hour, day of month, month and day of week,
+// in that order. It returns a descriptive error if the spec is not valid.
+//
+// It accepts
+//   - Standard crontab specs, e.g. "* * * * ?"
+//   - Descriptors, e.g. "@midnight", "@every 1h30m"
+func ParseStandard(standardSpec string) (Schedule, error) {
+	return standardParser.Parse(standardSpec)
+}
+
+var defaultParser = NewParser(
+	Second | Minute | Hour | Dom | Month | DowOptional | Descriptor,
+)
+
+// Parse returns a new crontab schedule representing the given spec.
+// It returns a descriptive error if the spec is not valid.
+//
+// It accepts
+//   - Full crontab specs, e.g. "* * * * * ?"
+//   - Descriptors, e.g. "@midnight", "@every 1h30m"
+func Parse(spec string) (Schedule, error) {
+	return defaultParser.Parse(spec)
+}
+
+// getField returns an Int with the bits set representing all of the times that
+// the field represents or error parsing field value.  A "field" is a comma-separated
+// list of "ranges".
+func getField(field string, r bounds) (uint64, error) {
+	var bits uint64
+	ranges := strings.FieldsFunc(field, func(r rune) bool { return r == ',' })
+	for _, expr := range ranges {
+		bit, err := getRange(expr, r)
+		if err != nil {
+			return bits, err
+		}
+		bits |= bit
+	}
+	return bits, nil
+}
+
+// getRange returns the bits indicated by the given expression:
+//   number | number "-" number [ "/" number ]
+// or error parsing range.
+func getRange(expr string, r bounds) (uint64, error) {
+	var (
+		start, end, step uint
+		rangeAndStep     = strings.Split(expr, "/")
+		lowAndHigh       = strings.Split(rangeAndStep[0], "-")
+		singleDigit      = len(lowAndHigh) == 1
+		err              error
+	)
+
+	var extra uint64
+	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
+		start = r.min
+		end = r.max
+		extra = starBit
+	} else {
+		start, err = parseIntOrName(lowAndHigh[0], r.names)
+		if err != nil {
+			return 0, err
+		}
+		switch len(lowAndHigh) {
+		case 1:
+			end = start
+		case 2:
+			end, err = parseIntOrName(lowAndHigh[1], r.names)
+			if err != nil {
+				return 0, err
+			}
+		default:
+			return 0, fmt.Errorf("Too many hyphens: %s", expr)
+		}
+	}
+
+	switch len(rangeAndStep) {
+	case 1:
+		step = 1
+	case 2:
+		step, err = mustParseInt(rangeAndStep[1])
+		if err != nil {
+			return 0, err
+		}
+
+		// Special handling: "N/step" means "N-max/step".
+		if singleDigit {
+			end = r.max
+		}
+	default:
+		return 0, fmt.Errorf("Too many slashes: %s", expr)
+	}
+
+	if start < r.min {
+		return 0, fmt.Errorf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
+	}
+	if end > r.max {
+		return 0, fmt.Errorf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
+	}
+	if start > end {
+		return 0, fmt.Errorf("Beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
+	}
+	if step == 0 {
+		return 0, fmt.Errorf("Step of range should be a positive number: %s", expr)
+	}
+
+	return getBits(start, end, step) | extra, nil
+}
+
+// parseIntOrName returns the (possibly-named) integer contained in expr.
+func parseIntOrName(expr string, names map[string]uint) (uint, error) {
+	if names != nil {
+		if namedInt, ok := names[strings.ToLower(expr)]; ok {
+			return namedInt, nil
+		}
+	}
+	return mustParseInt(expr)
+}
+
+// mustParseInt parses the given expression as an int or returns an error.
+func mustParseInt(expr string) (uint, error) {
+	num, err := strconv.Atoi(expr)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to parse int from %s: %s", expr, err)
+	}
+	if num < 0 {
+		return 0, fmt.Errorf("Negative number (%d) not allowed: %s", num, expr)
+	}
+
+	return uint(num), nil
+}
+
+// getBits sets all bits in the range [min, max], modulo the given step size.
+func getBits(min, max, step uint) uint64 {
+	var bits uint64
+
+	// If step is 1, use shifts.
+	if step == 1 {
+		return ^(math.MaxUint64 << (max + 1)) & (math.MaxUint64 << min)
+	}
+
+	// Else, use a simple loop.
+	for i := min; i <= max; i += step {
+		bits |= 1 << i
+	}
+	return bits
+}
+
+// all returns all bits within the given bounds.  (plus the star bit)
+func all(r bounds) uint64 {
+	return getBits(r.min, r.max, 1) | starBit
+}
+
+// parseDescriptor returns a predefined schedule for the expression, or error if none matches.
+func parseDescriptor(descriptor string) (Schedule, error) {
+	switch descriptor {
+	case "@yearly", "@annually":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  1 << months.min,
+			Dow:    all(dow),
+		}, nil
+
+	case "@monthly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+
+	case "@weekly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    1 << dow.min,
+		}, nil
+
+	case "@daily", "@midnight":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+
+	case "@hourly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   all(hours),
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+	}
+
+	const every = "@every "
+	if strings.HasPrefix(descriptor, every) {
+		duration, err := time.ParseDuration(descriptor[len(every):])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse duration %s: %s", descriptor, err)
+		}
+		return Every(duration), nil
+	}
+
+	return nil, fmt.Errorf("Unrecognized descriptor: %s", descriptor)
+}

--- a/vendor/github.com/robfig/cron/spec.go
+++ b/vendor/github.com/robfig/cron/spec.go
@@ -1,0 +1,158 @@
+package cron
+
+import "time"
+
+// SpecSchedule specifies a duty cycle (to the second granularity), based on a
+// traditional crontab specification. It is computed initially and stored as bit sets.
+type SpecSchedule struct {
+	Second, Minute, Hour, Dom, Month, Dow uint64
+}
+
+// bounds provides a range of acceptable values (plus a map of name to value).
+type bounds struct {
+	min, max uint
+	names    map[string]uint
+}
+
+// The bounds for each field.
+var (
+	seconds = bounds{0, 59, nil}
+	minutes = bounds{0, 59, nil}
+	hours   = bounds{0, 23, nil}
+	dom     = bounds{1, 31, nil}
+	months  = bounds{1, 12, map[string]uint{
+		"jan": 1,
+		"feb": 2,
+		"mar": 3,
+		"apr": 4,
+		"may": 5,
+		"jun": 6,
+		"jul": 7,
+		"aug": 8,
+		"sep": 9,
+		"oct": 10,
+		"nov": 11,
+		"dec": 12,
+	}}
+	dow = bounds{0, 6, map[string]uint{
+		"sun": 0,
+		"mon": 1,
+		"tue": 2,
+		"wed": 3,
+		"thu": 4,
+		"fri": 5,
+		"sat": 6,
+	}}
+)
+
+const (
+	// Set the top bit if a star was included in the expression.
+	starBit = 1 << 63
+)
+
+// Next returns the next time this schedule is activated, greater than the given
+// time.  If no time can be found to satisfy the schedule, return the zero time.
+func (s *SpecSchedule) Next(t time.Time) time.Time {
+	// General approach:
+	// For Month, Day, Hour, Minute, Second:
+	// Check if the time value matches.  If yes, continue to the next field.
+	// If the field doesn't match the schedule, then increment the field until it matches.
+	// While incrementing the field, a wrap-around brings it back to the beginning
+	// of the field list (since it is necessary to re-verify previous field
+	// values)
+
+	// Start at the earliest possible time (the upcoming second).
+	t = t.Add(1*time.Second - time.Duration(t.Nanosecond())*time.Nanosecond)
+
+	// This flag indicates whether a field has been incremented.
+	added := false
+
+	// If no time is found within five years, return zero.
+	yearLimit := t.Year() + 5
+
+WRAP:
+	if t.Year() > yearLimit {
+		return time.Time{}
+	}
+
+	// Find the first applicable month.
+	// If it's this month, then do nothing.
+	for 1<<uint(t.Month())&s.Month == 0 {
+		// If we have to add a month, reset the other parts to 0.
+		if !added {
+			added = true
+			// Otherwise, set the date at the beginning (since the current time is irrelevant).
+			t = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 1, 0)
+
+		// Wrapped around.
+		if t.Month() == time.January {
+			goto WRAP
+		}
+	}
+
+	// Now get a day in that month.
+	for !dayMatches(s, t) {
+		if !added {
+			added = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 0, 1)
+
+		if t.Day() == 1 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Hour())&s.Hour == 0 {
+		if !added {
+			added = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
+		}
+		t = t.Add(1 * time.Hour)
+
+		if t.Hour() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Minute())&s.Minute == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Minute)
+		}
+		t = t.Add(1 * time.Minute)
+
+		if t.Minute() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Second())&s.Second == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Second)
+		}
+		t = t.Add(1 * time.Second)
+
+		if t.Second() == 0 {
+			goto WRAP
+		}
+	}
+
+	return t
+}
+
+// dayMatches returns true if the schedule's day-of-week and day-of-month
+// restrictions are satisfied by the given time.
+func dayMatches(s *SpecSchedule, t time.Time) bool {
+	var (
+		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
+		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
+	)
+	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
+		return domMatch && dowMatch
+	}
+	return domMatch || dowMatch
+}

--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// OnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}
+
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
+//
+//     err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//         // Fetch the resource here; you need to refetch it on every try, since
+//         // if you got a conflict on the last update attempt then you need to get
+//         // the current version before making your own changes.
+//         pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//         if err ! nil {
+//             return err
+//         }
+//
+//         // Make whatever updates to the resource are needed
+//         pod.Status.Phase = v1.PodFailed
+//
+//         // Try to update
+//         _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//         // You have to return err itself here (not wrapped inside another error)
+//         // so that RetryOnConflict can identify it correctly.
+//         return err
+//     })
+//     if err != nil {
+//         // May be conflict if max retries were hit, or may be something unrelated
+//         // like permissions or a network error
+//         return err
+//     }
+//     ...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	return OnError(backoff, errors.IsConflict, fn)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,6 +114,8 @@ github.com/rancher/wrangler/pkg/signals
 github.com/rancher/wrangler/pkg/slice
 github.com/rancher/wrangler/pkg/start
 github.com/rancher/wrangler/pkg/yaml
+# github.com/robfig/cron v1.2.0
+github.com/robfig/cron
 # github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
@@ -346,6 +348,7 @@ k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/code-generator v0.18.0
 k8s.io/code-generator/cmd/client-gen/args


### PR DESCRIPTION
Added a new CRD to cis-operator:
Kind: ScheduledScan
APIVersion: "cis.cattle.io/v1"

```
type ScheduledScan struct {
	metav1.TypeMeta   `json:",inline"`
	metav1.ObjectMeta `json:"metadata,omitempty"`

	Spec   ScheduledScanSpec   `json:"spec"`
	Status ScheduledScanStatus `yaml:"status" json:"status,omitempty"`
}

type ScheduledScanSpec struct {
	// scan profile to use
	ScanProfileName string `json:"scanProfileName,omitempty"`
	// Cron Expression for Schedule
	CronSchedule string `yaml:"cron_schedule" json:"cronSchedule,omitempty"`
	// Number of past scans to keep
	RetentionCount int `yaml:"retentionCount" json:"retentionCount,omitempty"` //default=10
}

type ScheduledScanStatus struct {
	LastRunTimestamp   string                              `yaml:"last_run_timestamp" json:"lastRunTimestamp"`
	LastClusterScanName string
	ObservedGeneration int64                               `json:"observedGeneration"`
	Conditions         []genericcondition.GenericCondition `json:"conditions,omitempty"`
}
```

When user creates a ScheduledScan resource on the cluster, cis-operator will create ClusterScan CRs as per the cronschedule, to run the scan.
Each ClusterScan CR will carry an ownerreference to point to the ScheduledScan CR.

https://github.com/rancher/cis-operator/issues/27