### PR TITLE
Add field to set scan state based on warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist
 *.swp
 .idea
+/cis-operator

--- a/crds/clusterscan.yaml
+++ b/crds/clusterscan.yaml
@@ -48,6 +48,13 @@ spec:
             scanProfileName:
               nullable: true
               type: string
+            scoreWarning:
+              default: pass
+              enum:
+              - pass
+              - fail
+              nullable: true
+              type: string
           type: object
         status:
           properties:
@@ -112,6 +119,8 @@ spec:
                 skip:
                   type: integer
                 total:
+                  type: integer
+                warn:
                   type: integer
               type: object
           type: object

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/rancher/kubernetes-provider-detector v0.0.0-20200807181951-690274ab1fb3
 	github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0
-	github.com/rancher/security-scan v0.2.1
+	github.com/rancher/security-scan v0.2.2-0.20201117171930-af478b83fbe4
 	github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/rancher/kubernetes-provider-detector v0.0.0-20200807181951-690274ab1f
 github.com/rancher/kubernetes-provider-detector v0.0.0-20200807181951-690274ab1fb3/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0 h1:ng7i8n0kzTGnXyvVK+nkb+sLm06BBNdsbd2aqJAP3lM=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
-github.com/rancher/security-scan v0.2.1 h1:3PFS3k5hz0G0VflHVJdK65y680X6MwzRMbu/PlzD+YE=
-github.com/rancher/security-scan v0.2.1/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
+github.com/rancher/security-scan v0.2.2-0.20201117171930-af478b83fbe4 h1:WRfe56iR0TfelgaNgT01bL5TXmz4KFF55gyUna0cOGQ=
+github.com/rancher/security-scan v0.2.2-0.20201117171930-af478b83fbe4/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224 h1:NWYSyS1YiWJOB84xq0FcGDY8xQQwrfKoip2BjMSlu1g=
 github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/apis/cis.cattle.io/v1/types.go
+++ b/pkg/apis/cis.cattle.io/v1/types.go
@@ -33,6 +33,9 @@ const (
 	ClusterScanConditionAlerted      = condition.Cond("Alerted")
 	ClusterScanConditionReconciling  = condition.Cond("Reconciling")
 	ClusterScanConditionStalled      = condition.Cond("Stalled")
+
+	ClusterScanFailOnWarning = "fail"
+	ClusterScanPassOnWarning = "pass"
 )
 
 // +genclient
@@ -54,6 +57,8 @@ type ClusterScanSpec struct {
 	CronSchedule string `yaml:"cron_schedule" json:"cronSchedule,omitempty"`
 	// Number of past scans to keep
 	RetentionCount int `yaml:"retentionCount" json:"retentionCount,omitempty"`
+	// Specify if tests with "warn" output should be counted towards scan failure
+	ScoreWarning string `yaml:"score_warning" json:"scoreWarning,omitempty"`
 }
 
 type ClusterScanStatus struct {
@@ -78,6 +83,7 @@ type ClusterScanSummary struct {
 	Pass          int `json:"pass"`
 	Fail          int `json:"fail"`
 	Skip          int `json:"skip"`
+	Warn          int `json:"warn"`
 	NotApplicable int `json:"notApplicable"`
 }
 

--- a/pkg/securityscan/jobHandler.go
+++ b/pkg/securityscan/jobHandler.go
@@ -147,6 +147,7 @@ func (c *Controller) getScanSummary(outputBytes []byte) (*v1.ClusterScanSummary,
 		Pass:          r.Pass,
 		Fail:          r.Fail,
 		Skip:          r.Skip,
+		Warn:          r.Warn,
 		NotApplicable: r.NotApplicable,
 	}
 	return cisScanSummary, nil

--- a/pkg/securityscan/scanHandler.go
+++ b/pkg/securityscan/scanHandler.go
@@ -293,8 +293,14 @@ func (c Controller) setClusterScanStatusDisplay(scan *v1.ClusterScan) {
 			display.Message = "ClusterScan complete, there are some test failures, please check the ClusterScanReport"
 			display.Error = true
 		} else {
-			display.State = passedState
-			display.Error = false
+			if summary.Warn > 0 && scan.Spec.ScoreWarning == v1.ClusterScanFailOnWarning {
+				display.State = failedState
+				display.Message = "ClusterScan complete, warnings have been generated for some manual tests, please check the ClusterScanReport"
+				display.Error = true
+			} else {
+				display.State = passedState
+				display.Error = false
+			}
 		}
 		display.Transitioning = false
 	}

--- a/vendor/github.com/rancher/security-scan/pkg/kb-summarizer/report/report.go
+++ b/vendor/github.com/rancher/security-scan/pkg/kb-summarizer/report/report.go
@@ -25,6 +25,7 @@ const (
 	Fail          State = "fail"
 	Skip          State = "skip"
 	Mixed         State = "mixed"
+	Warn          State = "warn"
 	NotApplicable State = "notApplicable"
 )
 
@@ -42,6 +43,8 @@ type Check struct {
 	ConfigCommands []*exec.Cmd `json:"config_commands"`
 	ActualValue    string      `json:"actual_value"`
 	ExpectedResult string      `json:"expected_result"`
+	TestType       string      `json:"test_type"`
+	Scored         bool        `json:"scored"`
 }
 
 type Group struct {
@@ -56,6 +59,7 @@ type Report struct {
 	Pass          int                   `json:"pass"`
 	Fail          int                   `json:"fail"`
 	Skip          int                   `json:"skip"`
+	Warn          int                   `json:"warn"`
 	NotApplicable int                   `json:"notApplicable"`
 	Nodes         map[NodeType][]string `json:"nodes"`
 	Results       []*Group              `json:"results"`
@@ -83,6 +87,8 @@ func mapState(state summarizer.State) State {
 		return Skip
 	case summarizer.Mixed:
 		return Mixed
+	case summarizer.Warn:
+		return Warn
 	case summarizer.NotApplicable:
 		return NotApplicable
 	}
@@ -112,6 +118,8 @@ func mapCheck(intCheck *summarizer.CheckWrapper) *Check {
 		ConfigCommands: intCheck.ConfigCommands,
 		ActualValue:    intCheck.ActualValue,
 		ExpectedResult: intCheck.ExpectedResult,
+		TestType:       intCheck.Type,
+		Scored:         intCheck.Scored,
 	}
 }
 
@@ -152,6 +160,7 @@ func mapReport(internalReport *summarizer.SummarizedReport) (*Report, error) {
 	externalReport.Pass = internalReport.Pass
 	externalReport.Fail = internalReport.Fail
 	externalReport.Skip = internalReport.Skip
+	externalReport.Warn = internalReport.Warn
 	externalReport.NotApplicable = internalReport.NotApplicable
 	externalReport.Nodes = mapNodes(internalReport.Nodes)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,7 +77,7 @@ github.com/rancher/lasso/pkg/controller
 github.com/rancher/lasso/pkg/log
 github.com/rancher/lasso/pkg/mapper
 github.com/rancher/lasso/pkg/scheme
-# github.com/rancher/security-scan v0.2.1
+# github.com/rancher/security-scan v0.2.2-0.20201117171930-af478b83fbe4
 github.com/rancher/security-scan/pkg/kb-summarizer/report
 github.com/rancher/security-scan/pkg/kb-summarizer/summarizer
 # github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224


### PR DESCRIPTION
Manual tests generate "warn" output. If a scan has no failures, it should by default
have state "Pass" even if it ran manual tests with "warn" output. Along with that, cluster scan
spec should have a field with which users can make the Scan fail if it ran tests with "warn"
output. This field will be an enum with values pass|fail and default of pass. It is an enum so in
the future if we decide to add a state specific to "warn" output we can extend this.

This field is based on offline dicsussion with @deniseschannon on how to include "warn" tests in scan output.
Field name and type is discussed with/approved by @vincent99 

https://github.com/rancher/cis-operator/issues/54