### PR TITLE
Add Warn field to additionalPrinterColumns, remove scoreWarning default

### DIFF
--- a/crds/clusterscan.yaml
+++ b/crds/clusterscan.yaml
@@ -19,6 +19,9 @@ spec:
   - JSONPath: .status.summary.skip
     name: Skip
     type: string
+  - JSONPath: .status.summary.warn
+    name: Warn
+    type: string
   - JSONPath: .status.summary.notApplicable
     name: Not Applicable
     type: string
@@ -49,7 +52,6 @@ spec:
               nullable: true
               type: string
             scoreWarning:
-              default: pass
               enum:
               - pass
               - fail

--- a/pkg/crds/crd.go
+++ b/pkg/crds/crd.go
@@ -46,6 +46,7 @@ func List() []crd.CRD {
 				WithColumn("Pass", ".status.summary.pass").
 				WithColumn("Fail", ".status.summary.fail").
 				WithColumn("Skip", ".status.summary.skip").
+				WithColumn("Warn", ".status.summary.warn").
 				WithColumn("Not Applicable", ".status.summary.notApplicable").
 				WithColumn("LastRunTimestamp", ".status.lastRunTimestamp").
 				WithColumn("CronSchedule", ".spec.cronSchedule")
@@ -91,7 +92,6 @@ func customizeClusterScan(clusterScan *apiext.CustomResourceDefinition) {
 	passRaw, _ := json.Marshal(cisoperator.ClusterScanPassOnWarning)
 	failRaw, _ := json.Marshal(cisoperator.ClusterScanFailOnWarning)
 	scoreWarning.Enum = []apiext.JSON{{Raw: passRaw}, {Raw: failRaw}}
-	scoreWarning.Default = &apiext.JSON{Raw: passRaw}
 	spec.Properties["scoreWarning"] = scoreWarning
 	properties["spec"] = spec
 }


### PR DESCRIPTION
This commit adds the "Warn" field from status.summary as an additionalPrinterColumn.
It also removes the default value for scoreWarning. This is because the CRDs are of version
apiextensions.k8s.io/v1beta1. Setting a default in this version is not allowed. Although the
file crd.go specifies version as "v1", wrangler is generating CRD with version "apiextensions.k8s.io/v1beta1".
This could depend on the available versions in the cluster and can be investigated later.
For now in order to avoid any install issues, the default of "pass" is being removed. The logic to make the
scan fail checks the field specifically for "fail" value, so it won't be affected.