### PR TITLE
Custom benchmark for CIS scans

### DIFF
--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -14,7 +14,7 @@ data:
       hostIPC: true
       hostNetwork: true
       hostPID: true
-      serviceAccountName: {{.serviceaccount}}
+      serviceAccountName: {{ .serviceaccount }}
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/controlplane
@@ -38,6 +38,22 @@ data:
       - hostPath:
           path: /etc/cni/net.d
         name: rke2-cni
+      {{- if .isCustomBenchmark }}
+      - configMap:
+          defaultMode: 420
+          items:
+          {{- range $key, $value := .customBenchmarkConfigMapData }}
+          {{- if eq $key "config.yaml"}}
+          - key: {{ $key }}
+            path: {{ $key }}
+          {{- else}}
+          - key: {{ $key }}
+            path: {{ $.benchmarkVersion }}/{{ $key }}
+          {{- end }}
+          {{- end }}
+          name: {{ .customBenchmarkConfigMapName }}
+        name: custom-benchmark-volume
+      {{- end }}
     sonobuoy-config:
       driver: DaemonSet
       plugin-name: rancher-kube-bench
@@ -45,11 +61,11 @@ data:
       result-format: raw
     spec:
       name: rancher-kube-bench
-      image: {{.securityScanImage}}
+      image: {{ .securityScanImage }}
       command: ["/bin/bash", "-c", "run_sonobuoy_plugin.sh && sleep 3600"]
       env:
       - name: SONOBUOY_NS
-        value: {{.namespace}}
+        value: {{ .namespace }}
       - name: NODE_NAME
         valueFrom:
           fieldRef:
@@ -59,7 +75,11 @@ data:
       - name: CHROOT_DIR
         value: /node
       - name: OVERRIDE_BENCHMARK_VERSION
-        value: {{.benchmarkVersion}}
+        value: {{ .benchmarkVersion }}
+      {{- if .isCustomBenchmark }}
+      - name: CONFIG_DIR
+        value: {{ .configDir }}
+      {{- end }}
       imagePullPolicy: Always
       securityContext:
         privileged: true
@@ -82,3 +102,7 @@ data:
       - mountPath: /etc/cni/net.d
         name: rke2-cni
         readOnly: true
+      {{- if .isCustomBenchmark }}
+      - mountPath: /etc/kbs/custombenchmark/cfg
+        name: custom-benchmark-volume
+      {{- end }}

--- a/pkg/securityscan/jobHandler.go
+++ b/pkg/securityscan/jobHandler.go
@@ -60,9 +60,11 @@ func (c *Controller) handleJobs(ctx context.Context) error {
 		// if the scan has completed then delete the job
 		if v1.ClusterScanConditionComplete.IsTrue(scan) {
 			c.ensureCleanup(scan)
-			v1.ClusterScanConditionAlerted.Unknown(scan)
+			if !v1.ClusterScanConditionFailed.IsTrue(scan) {
+				logrus.Infof("Marking ClusterScanConditionAlerted for scan: %v", scanName)
+				v1.ClusterScanConditionAlerted.Unknown(scan)
+			}
 			scan.Status.ObservedGeneration = scan.Generation
-			logrus.Infof("Marking ClusterScanConditionAlerted for scan: %v", scanName)
 			c.setClusterScanStatusDisplay(scan)
 
 			if scan.Spec.ScheduledScanConfig != nil && scan.Spec.ScheduledScanConfig.CronSchedule != "" {


### PR DESCRIPTION
https://github.com/rancher/cis-operator/issues/6

- This PR adds support for adding custom benchmarks for CIS. 

How to create and scan using a Custom benchmark?
- User needs to create the test configs in a directory structure similar to https://github.com/rancher/security-scan/tree/master/package/cfg
- Thus if a user wants to add a new benchmark named say for example "my-k8s-benchmark", they should create a directory structure this way:
 - Create a folder cfg/my-k8s-benchmark
 - Place all files under cfg/my-k8s-benchmark - The files should be the yaml files similar to https://github.com/rancher/security-scan/tree/master/package/cfg/cis-1.6 but customized per your cluster setup
- Create a configmap using this folder and add it to the cluster
-  The user can then create a custom benchmark CR and specify this Configmap to be used by the cis-operator to load the test config contents (yaml files for testing k8s components) 
- Create a ClusterScanProfile CR to use this custom Benchmark
- Create a ClusterScan CR using this ClusterScanProfile

