### PR TITLE
CIS v2 Alerting and Custom Benchmark fixes

### DIFF
--- a/crds/clusterscan.yaml
+++ b/crds/clusterscan.yaml
@@ -28,7 +28,7 @@ spec:
   - JSONPath: .status.lastRunTimestamp
     name: LastRunTimestamp
     type: string
-  - JSONPath: .spec.cronSchedule
+  - JSONPath: .spec.scheduledScanConfig.cronSchedule
     name: CronSchedule
     type: string
   group: cis.cattle.io

--- a/crds/clusterscanbenchmark.yaml
+++ b/crds/clusterscanbenchmark.yaml
@@ -13,6 +13,12 @@ spec:
   - JSONPath: .spec.maxKubernetesVersion
     name: MaxKubernetesVersion
     type: string
+  - JSONPath: .spec.customBenchmarkConfigMapName
+    name: customBenchmarkConfigMapName
+    type: string
+  - JSONPath: .spec.customBenchmarkConfigMapNamespace
+    name: customBenchmarkConfigMapNamespace
+    type: string
   group: cis.cattle.io
   names:
     kind: ClusterScanBenchmark
@@ -31,7 +37,7 @@ spec:
             customBenchmarkConfigMapName:
               nullable: true
               type: string
-            customBenchmarkConfigMapNameSpace:
+            customBenchmarkConfigMapNamespace:
               nullable: true
               type: string
             maxKubernetesVersion:

--- a/examples/clusterscanrke.yml
+++ b/examples/clusterscanrke.yml
@@ -2,6 +2,11 @@
 apiVersion: cis.cattle.io/v1
 kind: ClusterScan
 metadata:
-  name: rke-cis
+  name: can-you-alert
 spec:
   scanProfileName: rke-profile-hardened
+  scheduledScanConfig:
+    cronSchedule: "*/2 * * * *"
+    scanAlertRule:
+      alertOnComplete: true
+      alertOnFailure: true

--- a/examples/custombenchmarkscan.yml
+++ b/examples/custombenchmarkscan.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScan
+metadata:
+  name: rke-cis-1.6-perm-custom
+spec:
+  scanProfileName: "rke-cis-1.6-permissive"

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	securityScanImageTag = "v0.2.1"
 	sonobuoyImage        = "rancher/sonobuoy-sonobuoy"
 	sonobuoyImageTag     = "v0.16.3"
+	clusterName          string
 )
 
 func main() {
@@ -104,6 +105,12 @@ func main() {
 			Value:       "warning",
 			Destination: &alertSeverity,
 		},
+		cli.StringFlag{
+			Name:        "clusterName",
+			EnvVar:      "CLUSTER_NAME",
+			Value:       "",
+			Destination: &clusterName,
+		},
 	}
 	app.Action = run
 
@@ -137,6 +144,7 @@ func run(c *cli.Context) {
 		SonobuoyImage:        sonobuoyImage,
 		SonobuoyImageTag:     sonobuoyImageTag,
 		AlertSeverity:        alertSeverity,
+		ClusterName:          clusterName,
 	}
 
 	if err := validateConfig(imgConfig); err != nil {

--- a/pkg/apis/cis.cattle.io/v1/types.go
+++ b/pkg/apis/cis.cattle.io/v1/types.go
@@ -159,4 +159,5 @@ type ScanImageConfig struct {
 	SonobuoyImage        string
 	SonobuoyImageTag     string
 	AlertSeverity        string
+	ClusterName          string
 }

--- a/pkg/apis/cis.cattle.io/v1/types.go
+++ b/pkg/apis/cis.cattle.io/v1/types.go
@@ -117,7 +117,7 @@ type ClusterScanBenchmarkSpec struct {
 	MaxKubernetesVersion string `json:"maxKubernetesVersion,omitempty"`
 
 	CustomBenchmarkConfigMapName      string `json:"customBenchmarkConfigMapName,omitempty"`
-	CustomBenchmarkConfigMapNameSpace string `json:"customBenchmarkConfigMapNameSpace,omitempty"`
+	CustomBenchmarkConfigMapNamespace string `json:"customBenchmarkConfigMapNamespace,omitempty"`
 }
 
 // +genclient

--- a/pkg/crds/crd.go
+++ b/pkg/crds/crd.go
@@ -49,7 +49,7 @@ func List() []crd.CRD {
 				WithColumn("Warn", ".status.summary.warn").
 				WithColumn("Not Applicable", ".status.summary.notApplicable").
 				WithColumn("LastRunTimestamp", ".status.lastRunTimestamp").
-				WithColumn("CronSchedule", ".spec.cronSchedule")
+				WithColumn("CronSchedule", ".spec.scheduledScanConfig.cronSchedule")
 		}),
 		newCRD(&cisoperator.ClusterScanProfile{}, func(c crd.CRD) crd.CRD {
 			return c.
@@ -64,7 +64,9 @@ func List() []crd.CRD {
 			return c.
 				WithColumn("ClusterProvider", ".spec.clusterProvider").
 				WithColumn("MinKubernetesVersion", ".spec.minKubernetesVersion").
-				WithColumn("MaxKubernetesVersion", ".spec.maxKubernetesVersion")
+				WithColumn("MaxKubernetesVersion", ".spec.maxKubernetesVersion").
+				WithColumn("customBenchmarkConfigMapName", ".spec.customBenchmarkConfigMapName").
+				WithColumn("customBenchmarkConfigMapNamespace", ".spec.customBenchmarkConfigMapNamespace")
 		}),
 	}
 }

--- a/pkg/securityscan/alert/prometheusrule.go
+++ b/pkg/securityscan/alert/prometheusrule.go
@@ -26,6 +26,7 @@ func NewPrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanpro
 		"scanProfileName": clusterscanprofile.Name,
 		"alertOnFailure":  clusterscan.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnFailure,
 		"alertOnComplete": clusterscan.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnComplete,
+		"failOnWarn":      clusterscan.Spec.ScoreWarning == cisoperatorapiv1.ClusterScanFailOnWarning,
 	}
 	scanAlertRule, err := generatePrometheusRule(clusterscan, templateName, templatePath, configdata)
 	if err != nil {

--- a/pkg/securityscan/alert/templates/prometheusrule.template
+++ b/pkg/securityscan/alert/templates/prometheusrule.template
@@ -12,9 +12,13 @@ spec:
 {{- if .alertOnFailure }}
     - alert: CISScanHasFailures
       annotations:
-        description: CIS ClusterScan "{{ .scanName }}" has {{ "{{ $value }}" }} test failures
+        description: CIS ClusterScan "{{ .scanName }}" has {{ "{{ $value }}" }} test failures or warnings
         summary: CIS ClusterScan has tests failures
+      {{- if .failOnWarn }}
+      expr: cis_scan_num_tests_fail{scan_name="{{ .scanName }}"} > 0 or ON(scan_name) cis_scan_num_tests_warn{scan_name="{{ .scanName }}"} > 0
+      {{- else }}
       expr: cis_scan_num_tests_fail{scan_name="{{ .scanName }}"} > 0
+      {{- end }}
       for: 1m
       labels:
         severity: {{ .severity }}

--- a/pkg/securityscan/controller.go
+++ b/pkg/securityscan/controller.go
@@ -186,6 +186,7 @@ func initializeMetrics(ctl *Controller) error {
 			"scan_name",
 			// name of the clusterScanProfile used for scanning
 			"scan_profile_name",
+			"cluster_name",
 		},
 	)
 	if err := prometheus.Register(ctl.numTestsFailed); err != nil {
@@ -202,6 +203,7 @@ func initializeMetrics(ctl *Controller) error {
 			"scan_name",
 			// name of the clusterScanProfile used for scanning
 			"scan_profile_name",
+			"cluster_name",
 		},
 	)
 	if err := prometheus.Register(ctl.numScansComplete); err != nil {
@@ -218,6 +220,7 @@ func initializeMetrics(ctl *Controller) error {
 			"scan_name",
 			// name of the clusterScanProfile used for scanning
 			"scan_profile_name",
+			"cluster_name",
 		},
 	)
 	if err := prometheus.Register(ctl.numTestsTotal); err != nil {
@@ -234,6 +237,7 @@ func initializeMetrics(ctl *Controller) error {
 			"scan_name",
 			// name of the clusterScanProfile used for scanning
 			"scan_profile_name",
+			"cluster_name",
 		},
 	)
 	if err := prometheus.Register(ctl.numTestsPassed); err != nil {
@@ -250,6 +254,7 @@ func initializeMetrics(ctl *Controller) error {
 			"scan_name",
 			// name of the clusterScanProfile used for scanning
 			"scan_profile_name",
+			"cluster_name",
 		},
 	)
 	if err := prometheus.Register(ctl.numTestsSkipped); err != nil {
@@ -266,6 +271,7 @@ func initializeMetrics(ctl *Controller) error {
 			"scan_name",
 			// name of the clusterScanProfile used for scanning
 			"scan_profile_name",
+			"cluster_name",
 		},
 	)
 	if err := prometheus.Register(ctl.numTestsNA); err != nil {

--- a/pkg/securityscan/controller.go
+++ b/pkg/securityscan/controller.go
@@ -50,6 +50,7 @@ type Controller struct {
 	numTestsTotal    *prometheus.GaugeVec
 	numTestsNA       *prometheus.GaugeVec
 	numTestsPassed   *prometheus.GaugeVec
+	numTestsWarn     *prometheus.GaugeVec
 }
 
 func NewController(ctx context.Context, cfg *rest.Config, namespace, name string, imgConfig *cisoperatorapiv1.ScanImageConfig) (ctl *Controller, err error) {
@@ -275,6 +276,23 @@ func initializeMetrics(ctl *Controller) error {
 		},
 	)
 	if err := prometheus.Register(ctl.numTestsNA); err != nil {
+		return err
+	}
+
+	ctl.numTestsWarn = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cis_scan_num_tests_warn",
+			Help: "Number of tests having warn status in the CIS scans, partioned by scan_name, scan_profile_name",
+		},
+		[]string{
+			// scan_name will be set to "manual" for on-demand manual scans and the actual name set for the scheduled scans
+			"scan_name",
+			// name of the clusterScanProfile used for scanning
+			"scan_profile_name",
+			"cluster_name",
+		},
+	)
+	if err := prometheus.Register(ctl.numTestsWarn); err != nil {
 		return err
 	}
 

--- a/pkg/securityscan/core/configmap.go
+++ b/pkg/securityscan/core/configmap.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"text/template"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8Yaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -45,19 +43,15 @@ func NewConfigMaps(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanprofile
 	}
 	cmMap["configcm"] = configcm
 
-	logrus.Infof("CustomBenchmarkConfigMapName Set: %v %v", clusterscanbenchmark.Spec.CustomBenchmarkConfigMapName, clusterscanbenchmark.Spec.CustomBenchmarkConfigMapNamespace)
-
 	var isCustomBenchmark bool
 	customBenchmarkConfigMapData := make(map[string]string)
 	if clusterscanbenchmark.Spec.CustomBenchmarkConfigMapName != "" {
 		isCustomBenchmark = true
 		customcm, err := getCustomBenchmarkConfigMap(clusterscanbenchmark, configmapsClient)
 		if err != nil {
-			logrus.Infof("Error getting customBenchmarkConfigMapData: %v ", clusterscanbenchmark)
 			return cmMap, err
 		}
 		customBenchmarkConfigMapData = customcm.Data
-		logrus.Infof("customBenchmarkConfigMapData: %v ", customBenchmarkConfigMapData)
 	}
 
 	plugindata := map[string]interface{}{
@@ -77,7 +71,6 @@ func NewConfigMaps(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanprofile
 	if err != nil {
 		return cmMap, err
 	}
-	logrus.Infof("plugincm: %v ", plugincm.Data)
 	cmMap["plugincm"] = plugincm
 
 	var skipConfigcm *corev1.ConfigMap
@@ -100,12 +93,10 @@ func generateConfigMap(clusterscan *cisoperatorapiv1.ClusterScan, templateName s
 
 	obj, err := parseTemplate(clusterscan, templateName, templateFile, data)
 	if err != nil {
-		logrus.Infof("Error parsing plugincm: %v ", err)
 		return nil, err
 	}
 
 	if err := obj.Decode(&configcm); err != nil {
-		logrus.Infof("Error decoding plugincm: %v ", err)
 		return nil, err
 	}
 	return configcm, nil
@@ -155,8 +146,5 @@ func getCustomBenchmarkConfigMap(benchmark *cisoperatorapiv1.ClusterScanBenchmar
 	if benchmark.Spec.CustomBenchmarkConfigMapName == "" {
 		return nil, nil
 	}
-	logrus.Infof("benchmark.Spec.CustomBenchmarkConfigMapNamespace %v", benchmark.Spec.CustomBenchmarkConfigMapNamespace)
-	logrus.Infof("benchmark.Spec.CustomBenchmarkConfigMapName %v", benchmark.Spec.CustomBenchmarkConfigMapName)
-
 	return configmapsClient.Get(benchmark.Spec.CustomBenchmarkConfigMapNamespace, benchmark.Spec.CustomBenchmarkConfigMapName, metav1.GetOptions{})
 }

--- a/pkg/securityscan/scanHandler.go
+++ b/pkg/securityscan/scanHandler.go
@@ -79,21 +79,6 @@ func (c *Controller) handleClusterScans(ctx context.Context) error {
 					return objects, obj.Status, nil
 				}
 
-				if obj.Spec.ScheduledScanConfig != nil && obj.Spec.ScheduledScanConfig.ScanAlertRule != nil {
-					if obj.Status.ScanAlertingRuleName == "" {
-						alertRule, err := cisalert.NewPrometheusRule(obj, profile, c.ImageConfig)
-						if err != nil {
-							v1.ClusterScanConditionReconciling.True(obj)
-							return objects, obj.Status, fmt.Errorf("Error when trying to create a PrometheusRule: %v", err)
-						}
-						ruleCreated, err := c.monitoringClient.PrometheusRules(v1.ClusterScanNS).Create(ctx, alertRule, metav1.CreateOptions{})
-						if err != nil {
-							v1.ClusterScanConditionReconciling.True(obj)
-							return objects, obj.Status, fmt.Errorf("Error when creating PrometheusRule: %v", err)
-						}
-						obj.Status.ScanAlertingRuleName = ruleCreated.Name
-					}
-				}
 				if err := c.isRunnerPodPresent(); err != nil {
 					return objects, obj.Status, fmt.Errorf("Retrying ClusterScan %v since got error: %v ", obj.Name, err)
 				}
@@ -119,6 +104,23 @@ func (c *Controller) handleClusterScans(ctx context.Context) error {
 				}
 				objects = append(objects, cisjob.New(obj, profile, c.Name, c.ImageConfig), cmMap["configcm"], cmMap["plugincm"], cmMap["skipConfigcm"], service)
 
+				if obj.Spec.ScheduledScanConfig != nil && obj.Spec.ScheduledScanConfig.ScanAlertRule != nil {
+					if obj.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnComplete || obj.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnFailure {
+						if obj.Status.ScanAlertingRuleName == "" {
+							alertRule, err := cisalert.NewPrometheusRule(obj, profile, c.ImageConfig)
+							if err != nil {
+								v1.ClusterScanConditionReconciling.True(obj)
+								return objects, obj.Status, fmt.Errorf("Error when trying to create a PrometheusRule: %v", err)
+							}
+							ruleCreated, err := c.monitoringClient.PrometheusRules(v1.ClusterScanNS).Create(ctx, alertRule, metav1.CreateOptions{})
+							if err != nil {
+								v1.ClusterScanConditionReconciling.True(obj)
+								return objects, obj.Status, fmt.Errorf("Error when creating PrometheusRule: %v", err)
+							}
+							obj.Status.ScanAlertingRuleName = ruleCreated.Name
+						}
+					}
+				}
 				if v1.ClusterScanConditionFailed.IsTrue(obj) {
 					//clear the earlier failed status
 					v1.ClusterScanConditionFailed.False(obj)

--- a/pkg/securityscan/scanHandler.go
+++ b/pkg/securityscan/scanHandler.go
@@ -114,10 +114,10 @@ func (c *Controller) handleClusterScans(ctx context.Context) error {
 							}
 							ruleCreated, err := c.monitoringClient.PrometheusRules(v1.ClusterScanNS).Create(ctx, alertRule, metav1.CreateOptions{})
 							if err != nil {
-								v1.ClusterScanConditionReconciling.True(obj)
-								return objects, obj.Status, fmt.Errorf("Error when creating PrometheusRule: %v", err)
+								logrus.Errorf("Alerts will not be sent out for this scan %v due to this error when creating PrometheusRule: %v", obj.Name, err)
+							} else {
+								obj.Status.ScanAlertingRuleName = ruleCreated.Name
 							}
-							obj.Status.ScanAlertingRuleName = ruleCreated.Name
 						}
 					}
 				}

--- a/pkg/securityscan/scanMetricsHandler.go
+++ b/pkg/securityscan/scanMetricsHandler.go
@@ -34,13 +34,16 @@ func (c *Controller) handleClusterScanMetrics(ctx context.Context) error {
 		numTestsNA := float64(obj.Status.Summary.NotApplicable)
 		numTestsSkip := float64(obj.Status.Summary.Skip)
 		numTestsPass := float64(obj.Status.Summary.Pass)
+		clusterName := c.ImageConfig.ClusterName
 
-		c.numTestsFailed.WithLabelValues(scanName, scanProfileName).Set(numTestsFailed)
-		c.numScansComplete.WithLabelValues(scanName, scanProfileName).Inc()
-		c.numTestsTotal.WithLabelValues(scanName, scanProfileName).Set(numTestsTotal)
-		c.numTestsPassed.WithLabelValues(scanName, scanProfileName).Set(numTestsPass)
-		c.numTestsSkipped.WithLabelValues(scanName, scanProfileName).Set(numTestsSkip)
-		c.numTestsNA.WithLabelValues(scanName, scanProfileName).Set(numTestsNA)
+		logrus.Infof("clusterName %v", clusterName)
+
+		c.numTestsFailed.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsFailed)
+		c.numScansComplete.WithLabelValues(scanName, scanProfileName, clusterName).Inc()
+		c.numTestsTotal.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsTotal)
+		c.numTestsPassed.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsPass)
+		c.numTestsSkipped.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsSkip)
+		c.numTestsNA.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsNA)
 
 		logrus.Debugf("Done updating metrics for scan %v", obj.Name)
 

--- a/pkg/securityscan/scanMetricsHandler.go
+++ b/pkg/securityscan/scanMetricsHandler.go
@@ -34,9 +34,8 @@ func (c *Controller) handleClusterScanMetrics(ctx context.Context) error {
 		numTestsNA := float64(obj.Status.Summary.NotApplicable)
 		numTestsSkip := float64(obj.Status.Summary.Skip)
 		numTestsPass := float64(obj.Status.Summary.Pass)
+		numTestsWarn := float64(obj.Status.Summary.Warn)
 		clusterName := c.ImageConfig.ClusterName
-
-		logrus.Infof("clusterName %v", clusterName)
 
 		c.numTestsFailed.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsFailed)
 		c.numScansComplete.WithLabelValues(scanName, scanProfileName, clusterName).Inc()
@@ -44,6 +43,7 @@ func (c *Controller) handleClusterScanMetrics(ctx context.Context) error {
 		c.numTestsPassed.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsPass)
 		c.numTestsSkipped.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsSkip)
 		c.numTestsNA.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsNA)
+		c.numTestsWarn.WithLabelValues(scanName, scanProfileName, clusterName).Set(numTestsWarn)
 
 		logrus.Debugf("Done updating metrics for scan %v", obj.Name)
 
@@ -54,13 +54,13 @@ func (c *Controller) handleClusterScanMetrics(ctx context.Context) error {
 					(obj.Spec.ScheduledScanConfig.ScanAlertRule != nil &&
 						!obj.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnComplete &&
 						!obj.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnFailure) {
-					logrus.Infof("No AlertRules configured for scan %v", obj.Name)
+					logrus.Debugf("No AlertRules configured for scan %v", obj.Name)
 					v1.ClusterScanConditionAlerted.False(obj)
 					v1.ClusterScanConditionAlerted.Message(obj, "No AlertRule configured for this scan")
 				} else if obj.Status.ScanAlertingRuleName == "" {
-					logrus.Infof("Error creating PrometheusRule for scan %v", obj.Name)
+					logrus.Debugf("Error creating PrometheusRule for scan %v", obj.Name)
 					v1.ClusterScanConditionAlerted.False(obj)
-					v1.ClusterScanConditionAlerted.Message(obj, "Alerts will not work due to the error creating PrometheusRule")
+					v1.ClusterScanConditionAlerted.Message(obj, "Alerts will not work due to the error creating PrometheusRule, Please check if Monitoring app is installed")
 				} else {
 					v1.ClusterScanConditionAlerted.True(obj)
 				}

--- a/pkg/securityscan/scanMetricsHandler.go
+++ b/pkg/securityscan/scanMetricsHandler.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/client-go/util/retry"
+
 	v1 "github.com/rancher/cis-operator/pkg/apis/cis.cattle.io/v1"
 )
 
@@ -19,16 +21,7 @@ func (c *Controller) handleClusterScanMetrics(ctx context.Context) error {
 		if !(v1.ClusterScanConditionAlerted.IsUnknown(obj) && v1.ClusterScanConditionComplete.IsTrue(obj)) {
 			return obj, nil
 		}
-		if obj.Spec.ScheduledScanConfig != nil && obj.Spec.ScheduledScanConfig.ScanAlertRule == nil {
-			logrus.Debugf("No AlertRules configured for scan %v", obj.Name)
-			v1.ClusterScanConditionAlerted.False(obj)
-			v1.ClusterScanConditionAlerted.Message(obj, "No AlertRule configured for this scan")
-			_, err := scans.UpdateStatus(obj)
-			if err != nil {
-				return obj, fmt.Errorf("Retrying, got error %v in updating condition of scan object: %v ", err, obj.Name)
-			}
-			return obj, nil
-		}
+
 		logrus.Debugf("Updating metrics for scan %v", obj.Name)
 
 		scanName := "manual"
@@ -50,11 +43,33 @@ func (c *Controller) handleClusterScanMetrics(ctx context.Context) error {
 		c.numTestsNA.WithLabelValues(scanName, scanProfileName).Set(numTestsNA)
 
 		logrus.Debugf("Done updating metrics for scan %v", obj.Name)
-		v1.ClusterScanConditionAlerted.True(obj)
-		_, err := scans.UpdateStatus(obj)
-		if err != nil {
-			return obj, fmt.Errorf("Retrying, got error %v in updating condition of scan object: %v ", err, obj.Name)
+
+		if obj.Spec.ScheduledScanConfig != nil {
+			updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				var err error
+				if obj.Spec.ScheduledScanConfig.ScanAlertRule == nil ||
+					(obj.Spec.ScheduledScanConfig.ScanAlertRule != nil &&
+						!obj.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnComplete &&
+						!obj.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnFailure) {
+					logrus.Infof("No AlertRules configured for scan %v", obj.Name)
+					v1.ClusterScanConditionAlerted.False(obj)
+					v1.ClusterScanConditionAlerted.Message(obj, "No AlertRule configured for this scan")
+				} else if obj.Status.ScanAlertingRuleName == "" {
+					logrus.Infof("Error creating PrometheusRule for scan %v", obj.Name)
+					v1.ClusterScanConditionAlerted.False(obj)
+					v1.ClusterScanConditionAlerted.Message(obj, "Alerts will not work due to the error creating PrometheusRule")
+				} else {
+					v1.ClusterScanConditionAlerted.True(obj)
+				}
+				_, err = scans.UpdateStatus(obj)
+				return err
+			})
+
+			if updateErr != nil {
+				return obj, fmt.Errorf("Retrying, got error %v in updating condition of scan object: %v ", updateErr, obj.Name)
+			}
 		}
+
 		return obj, nil
 	})
 	return nil


### PR DESCRIPTION
This PR adds following changes:

https://github.com/rancher/cis-operator/issues/69
- Corrects the json tag and name of  field CustomBenchmarkConfigMapNamespace in ClusterScanBenchmark (It had capital S in 'Namespace' )  
- Also corrected the additionalPrinterColumn to print the scan.spec.scheduledScanConfig.CronSchedule correctly
- rancher-cis-benchmark chart changes needed are here https://github.com/rancher/charts/pull/881

https://github.com/rancher/cis-operator/issues/66
-  Ensure that ScanAlertRule.AlertOnComplete or ScanAlertRule.AlertOnFailure is set (and not just ScanAlertRule != nil) before creating PrometheusRule for these alerts

https://github.com/rancher/cis-operator/issues/70
- If create on PrometheusRule errors out, log the error about alerts will not work but proceed with the scan

https://github.com/rancher/cis-operator/issues/68
- Add new metric "cis_scan_num_tests_warn" to send number of tests in "Warn" state when a scan completes
- And also configure AlertOnFailure rule to include warn tests if user has set "Scan state for "warn" results: Fail"
- Also added "cluster_name" label to the metrics exported - the value will be set when the chart is installed 