### PR TITLE
Pass custombenchmark config dir as env and  add the configmap volume to scan-runner job

### DIFF
--- a/pkg/apis/cis.cattle.io/v1/types.go
+++ b/pkg/apis/cis.cattle.io/v1/types.go
@@ -24,6 +24,8 @@ const (
 	DefaultScanOutputFileName          = "output.json"
 	DefaultRetention                   = 3
 	DefaultCronSchedule                = "0 0 * * *"
+	CustomBenchmarkBaseDir             = "/etc/kbs/custombenchmark/cfg"
+	CustomBenchmarkConfigMap           = "cis-bmark-cm"
 
 	ClusterScanConditionCreated      = condition.Cond("Created")
 	ClusterScanConditionPending      = condition.Cond("Pending")


### PR DESCRIPTION
When a clusterscan runs, it creates:
- a scan-runner pod (that runs the report summarizer tool from security-scan repo)
- and a daemonset which runs kube-bench to scan the cluster

Along with adding the custom benchmark configmap (that user uploads) to the daemonset, we also need to add it as a volume to the scan-runner pod so that the  report summarizer tool has access to the custom configs in the benchmark.

This PR adds the configmap as a volume mount to the scan-runner job, otherwise the scan reports are not generated correctly.

Corresponding summarizer tool change: https://github.com/rancher/security-scan/pull/38

https://github.com/rancher/cis-operator/issues/69

