### PR TITLE
CriticalAddonsOnly toleration to support RKE2

### DIFF
--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -22,6 +22,9 @@ data:
       - effect: NoExecute
         key: node-role.kubernetes.io/etcd
         operator: Exists
+      - effect: NoExecute
+        key: CriticalAddonsOnly
+        operator: Exists        
       volumes:
       - hostPath:
           path: /


### PR DESCRIPTION
The recommendation for RKE2 deployments (found here: https://docs.rke2.io/install/ha/#2a-optional-consider-server-node-taints) is to taint Server nodes with CriticalAddonsOnly=true:NoExecute. As a result, the CIS Operator appears to not properly scan server nodes. When modifying this manually in a cluster I have deployed, the operator appears to work properly.