### PR TITLE
Update alpine version in Dockerfile for security fixes

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.14.2
 COPY pkg/ pkg/
 
 COPY bin/cis-operator /usr/bin/


### PR DESCRIPTION
Update alpine version in dockerfile to 3.14.2 

Trivy
-
```
rancher/cis-operator:af23fc2-amd64 (alpine 3.14.2)
==================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/bin/cis-operator (gobinary)
===============================
Total: 0 (HIGH: 0, CRITICAL: 0)
```

cis scan results can be found here: https://github.com/rancher/security-scan/pull/53#issuecomment-915649728