### PR TITLE
Remove linux/arm drone target

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -141,7 +141,6 @@ steps:
     platforms:
       - linux/amd64
       - linux/arm64
-      - linux/arm
     target: "rancher/cis-operator:${DRONE_TAG}"
     template: "rancher/cis-operator:${DRONE_TAG}-ARCH"
   when:


### PR DESCRIPTION
- Seems this change is remaining to remove arm target from drone. 
- Original change https://github.com/rancher/cis-operator/pull/128
