### PR TITLE
Implement drone-plugin-fossa

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -155,3 +155,19 @@ steps:
 depends_on:
 - amd64
 - arm64
+
+---
+
+kind: pipeline
+name: fossa
+
+steps:
+- name: fossa
+  image: rancher/drone-fossa:latest
+  settings:
+    api_key:
+      from_secret: FOSSA_API_KEY
+  when:
+    instance:
+      - drone-publish.rancher.io
+


### PR DESCRIPTION
By default, this plugin will run the analyze command per the generic CI documentation for FOSSA.