### PR TITLE
Added 'control-plane' toleration to support RKE2

### DIFF
--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -19,12 +19,15 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/controlplane
         operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - effect: NoExecute
         key: node-role.kubernetes.io/etcd
         operator: Exists
       - effect: NoExecute
         key: CriticalAddonsOnly
-        operator: Exists        
+        operator: Exists
       volumes:
       - hostPath:
           path: /


### PR DESCRIPTION
Fixes:
- This PR is an extension of this [PR](https://github.com/rancher/cis-operator/pull/101)
- The RKE2 clusters have a taint `node-role.kubernetes.io/control-plane` for which toleration was not present in rancher/cis-operator due to which CIS scan was failing with multiple errors. Same has been added.

Linked Issues:
https://github.com/rancher/rancher/issues/37129