### PR TITLE
Add node selector

### DIFF
--- a/pkg/securityscan/job/job.go
+++ b/pkg/securityscan/job/job.go
@@ -91,6 +91,9 @@ func New(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanprofile *cisopera
 					Tolerations: append([]corev1.Toleration{{
 						Operator: corev1.TolerationOpExists,
 					}}),
+					NodeSelector: labels.Set{
+						"kubernetes.io/os": "linux",
+					},
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes: []corev1.Volume{{
 						Name: `s-config-volume`,


### PR DESCRIPTION
**Problem**:
The security-scan pod get's provisioned on the windows node which is not supported and results in the scan running indefinitely.

**Solution**:
Add node selector so that the pods only get provisioned on linux nodes. 

Linked issue:
https://github.com/rancher/rancher/issues/38664