### PR TITLE
Update imagePullPolicy for security-scan 

### DIFF
--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -95,7 +95,7 @@ data:
       - name: CONFIG_DIR
         value: {{ .configDir }}
       {{- end }}
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       securityContext:
         privileged: true
       volumeMounts:

--- a/pkg/securityscan/job/job.go
+++ b/pkg/securityscan/job/job.go
@@ -172,7 +172,7 @@ func New(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanprofile *cisopera
 					Containers: []corev1.Container{{
 						Name:            `rancher-cis-benchmark`,
 						Image:           imageConfig.SecurityScanImage + ":" + imageConfig.SecurityScanImageTag,
-						ImagePullPolicy: corev1.PullAlways,
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: &privileged,
 						},


### PR DESCRIPTION
Updated the image pull policy to `IfNotPresent` so that if the image already exists it won't be pulled from the registry. 

Linked issues: 
https://github.com/rancher/rancher/issues/39673
https://github.com/rancher/rancher/issues/39685
SURE: 5093