### PR TITLE
Add profile name in the generated/downloaded scan report

### DIFF
--- a/pkg/securityscan/jobHandler.go
+++ b/pkg/securityscan/jobHandler.go
@@ -168,7 +168,7 @@ func (c *Controller) getScanSummary(outputBytes []byte) (*v1.ClusterScanSummary,
 func (c *Controller) createClusterScanReport(ctx context.Context, outputBytes []byte, scan *v1.ClusterScan) (*v1.ClusterScanReport, error) {
 	scanReport := &v1.ClusterScanReport{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: name.SafeConcatName("scan-report", scan.Name) + "-",
+			GenerateName: name.SafeConcatName("scan-report", scan.Name, scan.Spec.ScanProfileName) + "-",
 		},
 	}
 	profile, err := c.getClusterScanProfile(ctx, scan)


### PR DESCRIPTION
Related issue: https://github.com/rancher/cis-operator/issues/39
This PR adds the scan profile name in the generated scan report.
RKE2 -  permissive:
![Screenshot from 2023-01-13 13-40-34](https://user-images.githubusercontent.com/32811240/212288771-d4a73daf-2082-413f-b45d-e4342f9629ab.png)

RKE2 - hardened:  
![Screenshot from 2023-01-13 13-44-25](https://user-images.githubusercontent.com/32811240/212288792-1dd4078d-2749-4dbc-bf38-592c57fce14e.png)
