### PR TITLE
Embed templates into final binary

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,11 +1,5 @@
 FROM registry.suse.com/bci/bci-busybox:15.5
 
-COPY pkg/ pkg/
-
-# Ensure 65535 can access the templates in
-# pkg/securityscan/core/templates
-RUN chmod -R +xr pkg/
-
 COPY bin/cis-operator /usr/bin/
 
 USER 65535:65535

--- a/pkg/crds/crd.go
+++ b/pkg/crds/crd.go
@@ -3,7 +3,7 @@ package crds
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	cisoperator "github.com/rancher/cis-operator/pkg/apis/cis.cattle.io/v1"
@@ -37,7 +37,7 @@ func WriteCRD() error {
 		}
 
 		filename := fmt.Sprintf("./crds/%s.yaml", strings.ToLower(crd.Spec.Names.Kind))
-		err = ioutil.WriteFile(filename, yamlBytes, 0644)
+		err = os.WriteFile(filename, yamlBytes, 0o644)
 		if err != nil {
 			return err
 		}

--- a/pkg/securityscan/alert/prometheusrule.go
+++ b/pkg/securityscan/alert/prometheusrule.go
@@ -40,11 +40,11 @@ func generatePrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, templateN
 	scanAlertRule := &monitoringv1.PrometheusRule{}
 	obj, err := parseTemplate(clusterscan, templateName, templateFile, data)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing the template %v", err)
+		return nil, fmt.Errorf("Error parsing the template %w", err)
 	}
 
 	if err := obj.Decode(&scanAlertRule); err != nil {
-		return nil, fmt.Errorf("Error decoding to template %v", err)
+		return nil, fmt.Errorf("Error decoding to template %w", err)
 	}
 
 	ownerRef := meta1.OwnerReference{

--- a/pkg/securityscan/alert/prometheusrule.go
+++ b/pkg/securityscan/alert/prometheusrule.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"bytes"
+	_ "embed" // nolint
 	"fmt"
 	"text/template"
 
@@ -14,8 +15,10 @@ import (
 	"github.com/rancher/wrangler/pkg/name"
 )
 
+//go:embed templates/prometheusrule.template
+var prometheusRuleTemplate string
+
 const templateName = "prometheusrule.template"
-const templatePath = "./pkg/securityscan/alert/templates/prometheusrule.template"
 
 func NewPrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanprofile *cisoperatorapiv1.ClusterScanProfile, imageConfig *cisoperatorapiv1.ScanImageConfig) (*monitoringv1.PrometheusRule, error) {
 	configdata := map[string]interface{}{
@@ -28,7 +31,7 @@ func NewPrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanpro
 		"alertOnComplete": clusterscan.Spec.ScheduledScanConfig.ScanAlertRule.AlertOnComplete,
 		"failOnWarn":      clusterscan.Spec.ScoreWarning == cisoperatorapiv1.ClusterScanFailOnWarning,
 	}
-	scanAlertRule, err := generatePrometheusRule(clusterscan, templateName, templatePath, configdata)
+	scanAlertRule, err := generatePrometheusRule(clusterscan, configdata)
 	if err != nil {
 		return scanAlertRule, err
 	}
@@ -36,9 +39,9 @@ func NewPrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanpro
 	return scanAlertRule, nil
 }
 
-func generatePrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, templateName string, templateFile string, data map[string]interface{}) (*monitoringv1.PrometheusRule, error) {
+func generatePrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, data map[string]interface{}) (*monitoringv1.PrometheusRule, error) {
 	scanAlertRule := &monitoringv1.PrometheusRule{}
-	obj, err := parseTemplate(clusterscan, templateName, templateFile, data)
+	obj, err := parseTemplate(clusterscan, data)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing the template %w", err)
 	}
@@ -58,8 +61,8 @@ func generatePrometheusRule(clusterscan *cisoperatorapiv1.ClusterScan, templateN
 	return scanAlertRule, nil
 }
 
-func parseTemplate(clusterscan *cisoperatorapiv1.ClusterScan, templateName string, templateFile string, data map[string]interface{}) (*k8Yaml.YAMLOrJSONDecoder, error) {
-	cmTemplate, err := template.New(templateName).ParseFiles(templateFile)
+func parseTemplate(clusterscan *cisoperatorapiv1.ClusterScan, data map[string]interface{}) (*k8Yaml.YAMLOrJSONDecoder, error) {
+	cmTemplate, err := template.New(templateName).Parse(prometheusRuleTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/securityscan/controller.go
+++ b/pkg/securityscan/controller.go
@@ -116,32 +116,32 @@ func NewController(ctx context.Context, cfg *rest.Config, namespace, name string
 	}
 	ctl.cisFactory, err = cisoperatorctl.NewFactoryFromConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Error building securityscan NewFactoryFromConfig: %s", err.Error())
+		return nil, fmt.Errorf("Error building securityscan NewFactoryFromConfig: %w", err)
 	}
 
 	ctl.batchFactory, err = batchctl.NewFactoryFromConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Error building batch NewFactoryFromConfig: %s", err.Error())
+		return nil, fmt.Errorf("Error building batch NewFactoryFromConfig: %w", err)
 	}
 
 	ctl.coreFactory, err = corectl.NewFactoryFromConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Error building core NewFactoryFromConfig: %s", err.Error())
+		return nil, fmt.Errorf("Error building core NewFactoryFromConfig: %w", err)
 	}
 
 	ctl.appsFactory, err = appsctl.NewFactoryFromConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Error building apps NewFactoryFromConfig: %s", err.Error())
+		return nil, fmt.Errorf("Error building apps NewFactoryFromConfig: %w", err)
 	}
 
 	ctl.monitoringClient, err = v1monitoringclient.NewForConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Error building v1 monitoring client from config: %s", err.Error())
+		return nil, fmt.Errorf("Error building v1 monitoring client from config: %w", err)
 	}
 
 	err = initializeMetrics(ctl)
 	if err != nil {
-		return nil, fmt.Errorf("Error registering CIS Metrics: %s", err.Error())
+		return nil, fmt.Errorf("Error registering CIS Metrics: %w", err)
 	}
 
 	ctl.scans = ctl.cisFactory.Cis().V1().ClusterScan()

--- a/pkg/securityscan/core/service.go
+++ b/pkg/securityscan/core/service.go
@@ -1,11 +1,16 @@
 package core
 
 import (
+	_ "embed" // nolint
+
 	"github.com/rancher/wrangler/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 
 	cisoperatorapiv1 "github.com/rancher/cis-operator/pkg/apis/cis.cattle.io/v1"
 )
+
+//go:embed templates/service.template
+var serviceTemplate string
 
 func NewService(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanprofile *cisoperatorapiv1.ClusterScanProfile, controllerName string) (service *corev1.Service, err error) {
 
@@ -15,17 +20,17 @@ func NewService(clusterscan *cisoperatorapiv1.ClusterScan, clusterscanprofile *c
 		"runName":   name.SafeConcatName("security-scan-runner", clusterscan.Name),
 		"appName":   "rancher-cis-benchmark",
 	}
-	service, err = generateService(clusterscan, "service.template", "./pkg/securityscan/core/templates/service.template", servicedata)
+	service, err = generateService(clusterscan, "service.template", serviceTemplate, servicedata)
 	if err != nil {
 		return nil, err
 	}
 	return service, nil
 }
 
-func generateService(clusterscan *cisoperatorapiv1.ClusterScan, templateName string, templateFile string, data map[string]interface{}) (*corev1.Service, error) {
+func generateService(clusterscan *cisoperatorapiv1.ClusterScan, templateName string, templContent string, data map[string]interface{}) (*corev1.Service, error) {
 	service := &corev1.Service{}
 
-	obj, err := parseTemplate(clusterscan, templateName, templateFile, data)
+	obj, err := parseTemplate(clusterscan, templateName, templContent, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/securityscan/scheduledScanHandler.go
+++ b/pkg/securityscan/scheduledScanHandler.go
@@ -36,7 +36,7 @@ func (c *Controller) handleScheduledClusterScans(ctx context.Context) error {
 
 			nextScanTime, err := time.Parse(time.RFC3339, obj.Status.NextScanAt)
 			if err != nil {
-				return obj, fmt.Errorf("scheduledScanHandler: retrying, got error %v in parsing NextScanAt %v time for scheduledScan: %v ", err, obj.Status.NextScanAt, obj.Name)
+				return obj, fmt.Errorf("scheduledScanHandler: retrying, got error %w in parsing NextScanAt %v time for scheduledScan: %s", err, obj.Status.NextScanAt, obj.Name)
 			}
 			if nextScanTime.After(time.Now()) {
 				logrus.Debugf("scheduledScanHandler: run time is later, skipping this run scheduledScan CR %v ", obj.Name)
@@ -66,7 +66,7 @@ func (c *Controller) handleScheduledClusterScans(ctx context.Context) error {
 			})
 
 			if updateErr != nil {
-				return obj, fmt.Errorf("Retrying, got error %v in updating status for scheduledScan: %v ", updateErr, obj.Name)
+				return obj, fmt.Errorf("Retrying, got error %w in updating status for scheduledScan: %s", updateErr, obj.Name)
 			}
 		}
 
@@ -80,7 +80,7 @@ func (c *Controller) validateScheduledScanSpec(scan *v1.ClusterScan) error {
 	if scan.Spec.ScheduledScanConfig != nil && scan.Spec.ScheduledScanConfig.CronSchedule != "" {
 		_, err := cron.ParseStandard(scan.Spec.ScheduledScanConfig.CronSchedule)
 		if err != nil {
-			return fmt.Errorf("error parsing invalid cron string for schedule: %v", err)
+			return fmt.Errorf("error parsing invalid cron string for schedule: %w", err)
 		}
 	}
 	return nil
@@ -93,7 +93,7 @@ func (c *Controller) getCronSchedule(scan *v1.ClusterScan) (cron.Schedule, error
 	}
 	cronSchedule, err := cron.ParseStandard(schedule)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing invalid cron string for schedule: %v", err)
+		return nil, fmt.Errorf("Error parsing invalid cron string for schedule: %w", err)
 	}
 	return cronSchedule, nil
 }
@@ -110,7 +110,7 @@ func (c *Controller) rescheduleScan(scan *v1.ClusterScan) error {
 	scans := c.cisFactory.Cis().V1().ClusterScan()
 	cronSchedule, err := c.getCronSchedule(scan)
 	if err != nil {
-		return fmt.Errorf("Cannot reschedule, Error parsing invalid cron string for schedule: %v", err)
+		return fmt.Errorf("Cannot reschedule, Error parsing invalid cron string for schedule: %w", err)
 	}
 	now := time.Now()
 	nextScanAt := cronSchedule.Next(now)
@@ -125,7 +125,7 @@ func (c *Controller) purgeOldClusterScanReports(obj *v1.ClusterScan) error {
 	retention := c.getRetentionCount(obj)
 	allClusterScanReportsList, err := reports.List(metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("error listing cluster scans for scheduledScan %v: %v", obj.Name, err)
+		return fmt.Errorf("error listing cluster scans for scheduledScan %v: %w", obj.Name, err)
 	}
 	allClusterScanReports := allClusterScanReportsList.Items
 	var clusterScanReports []v1.ClusterScanReport


### PR DESCRIPTION
Previously, templates were copied into the final image, together with all source code within the pkg dir.
The new approach avoids copying unnecessary files over to the final image, but instead embeds the templates into the target binary.