### PR TITLE
Fix version mismatch in Renovate

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,7 @@ FROM registry.suse.com/bci/golang:1.21
 # k3d and kubectl versions must be aligned with the Kubernetes versions
 # set in tests/k3s-bench-test.yaml.
 #  k3d is used for e2e tests and is not shipped on the final image.
-ARG K3D_VERSION=5.4.8
+ARG K3D_VERSION=v5.4.8
 ARG KUBERNETES_VERSION=1.28.0
 
 ENV GOLANGCI_LINT v1.55.2
@@ -16,7 +16,7 @@ RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT}; \
     fi
 
-RUN curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG="v${K3D_VERSION}" bash
+RUN curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG="${K3D_VERSION}" bash
 ADD --chown=root:root --chmod=755 \
     "https://dl.k8s.io/release/v${KUBERNETES_VERSION}/bin/linux/${ARCH}/kubectl" \
     /usr/local/bin/kubectl


### PR DESCRIPTION
Related PR: https://github.com/rancher/cis-operator/pull/240