### PR TITLE
build: Enable auto-bump for versions and checksums

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,4 +1,6 @@
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint
 GOLANGCI_VERSION ?= v1.56.0
+# renovate: datasource=github-release-attachments depName=k3d-io/k3d
 K3D_VERSION ?= v5.6.0
 
 KUBECTL_VERSION ?= 1.28.0
@@ -8,7 +10,11 @@ KUBECTL_SUM_arm64 ?= f5484bd9cac66b183c653abed30226b561f537d15346c605cc81d98095f
 KUBECTL_SUM_amd64 ?= 4717660fd1466ec72d59000bb1d9f5cdc91fac31d491043ca62b34398e0799ce
 KUBECTL_SUM = KUBECTL_SUM_amd64
 
+# renovate: datasource=github-release-attachments depName=rancher/security-scan
 SECURITY_SCAN_VERSION ?= v0.2.13
+# renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy
 SONOBUOY_VERSION ?= v0.56.16
+# renovate: datasource=github-release-attachments depName=coredns/coredns
 CORE_DNS_VERSION ?= 1.9.4
+# renovate: datasource=github-release-attachments depName=k3s-io/klipper-helm
 KLIPPER_HELM_VERSION ?= v0.7.4-build20221121


### PR DESCRIPTION
Uses the latest changes from https://github.com/rancher/renovate-config/pull/243 to enable auto bump for some of the dependencies. Kubectl will be handled as a separated PR, as it cannot be sourced from github releases.