### PR TITLE
Add /var/lib/cni hostPath and remove rke2 prefix in hostPath names

### DIFF
--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -40,13 +40,16 @@ data:
         name: etc-group
       - hostPath:
           path: /var/lib/rancher
-        name: rke2-root
+        name: var-rancher
       - hostPath:
           path: /etc/rancher
-        name: rke2-root-config
+        name: etc-rancher
       - hostPath:
           path: /etc/cni/net.d
-        name: rke2-cni
+        name: etc-cni
+      - hostPath:
+          path: /var/lib/cni
+        name: var-cni
       - hostPath:
           path: /var/log
         name: var-log
@@ -112,13 +115,16 @@ data:
         name: etc-group
         readOnly: true
       - mountPath: /var/lib/rancher
-        name: rke2-root
+        name: var-rancher
         readOnly: true
       - mountPath: /etc/rancher
-        name: rke2-root-config
+        name: etc-rancher
         readOnly: true
       - mountPath: /etc/cni/net.d
-        name: rke2-cni
+        name: etc-cni
+        readOnly: true
+      - mountPath: /var/lib/cni
+        name: var-cni
         readOnly: true
       - mountPath: /var/log/
         name: var-log


### PR DESCRIPTION
This PR contains the following:

1. Adds `/var/lib/cni` hostPath in `pkg/securityscan/core/templates/pluginConfig.template` to support kube-bench checks that rely on `/var/lib/cni` path.
2. Removes the rke2 prefix in hostPath names since the plugin is generic to all k8s distributions.