### PR TITLE
Change baseBranch in renovate.json to new default branch: main

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranches": [
-    "master"
+    "main"
   ],
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
In light of the recent change to switch the cis-operator's default branch from `master` to `main`, this PR modifies the `baseBranch` in renovate.json accordingly.