### PR TITLE
added security-scan versioning info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Benchmarks tests and the execution logic lives on [rancher/security-scan].
 ## Branches and Releases
 The current branch strategy for `rancher/cis-operator` is laid out below:
 
-| Branch                | Tag      | Rancher                |
-|-----------------------|----------|------------------------|
-| `main`                | `head`   | `main` branch (`head`) |
-| `release/v1.2`        | `v1.2.x` | `v2.9.x`               |
-| `release/v1.1`        | `v1.1.x` | `v2.8.x`               |
-| `master` (deprecated) | `v1.0.x` | `v2.7.x`,`v2.8.x`      |
+| Branch                | Tag      |Security-Scan          | Rancher                   |
+|-----------------------|----------|-----------------------|---------------------------|
+| `main`                | `head`   |`main` branch (`head`)`| `main` branch (`head`)    |
+| `release/v1.2`        | `v1.2.x` |`v0.4.x`               | `v2.9.x`                  |
+| `release/v1.1`        | `v1.1.x` |`v0.3.x`               | `v2.8.x`                  |
+| `master` (deprecated) | `v1.0.x` |`v0.2.x`               | `v2.7.x`,`v2.8.x`,`v2.9.x`|
 
 Note that it aligns with Rancher Manager releases to maximize compatibility
 within the ecosystem. This includes k8s dependencies that the Rancher release


### PR DESCRIPTION
issue: https://github.com/rancher/cis-operator/issues/362