### PR TITLE
[release/v1.3] un-rc Chart.yaml + values.yaml

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-cis-benchmark
 apiVersion: v1
-appVersion: v7.0.0-rc.3
+appVersion: v7.0.0
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security
 name: rancher-cis-benchmark
-version: 7.0.0-rc.3
+version: 7.0.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.3.0-rc.2
+    tag: v1.3.0
   securityScan:
     repository: rancher/security-scan
-    tag: v0.5.0-rc.2
+    tag: v0.5.0
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.2


### PR DESCRIPTION
UnRC-ing 7.0.0. 

The latest RC was rc.3. 
I have UnRCed both Chart.yaml and values.yaml. 

I must point out that in the `go.mod` file, we still have:
```
	github.com/rancher/security-scan v0.5.0-rc.2
```

