### PR TITLE
[release/v1.2] unrc the chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-cis-benchmark
 apiVersion: v1
-appVersion: v6.4.0-rc.2
+appVersion: v6.4.0
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security
 name: rancher-cis-benchmark
-version: 6.4.0-rc.2
+version: 6.4.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.2.0-rc.2
+    tag: v1.2.0
   securityScan:
     repository: rancher/security-scan
-    tag: v0.4.0-rc.2
+    tag: v0.4.0
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.2
@@ -45,7 +45,7 @@ global:
     clusterName: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.29.10
+    tag: v1.29.7
 
 alerts:
   enabled: false

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rancher/lasso v0.0.0-20240828170735-d79536cac289
-	github.com/rancher/security-scan v0.4.0-rc.2
+	github.com/rancher/security-scan v0.4.0
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.16

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM
 github.com/rancher/kubernetes-provider-detector v0.1.5/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20240828170735-d79536cac289 h1:gbV7qLOcEgyTgep2ocl8FFhfGOUMQuvfV5OIIENHWT4=
 github.com/rancher/lasso v0.0.0-20240828170735-d79536cac289/go.mod h1:Efx/+BbH3ivmnTPLu5cA3Gc9wT5oyGS0LBcqEuYTx+A=
-github.com/rancher/security-scan v0.4.0-rc.2 h1:bcY5MRvjg83cWgw6LnfbC4MSXXFBjsJPo5HkWoKeJ9E=
-github.com/rancher/security-scan v0.4.0-rc.2/go.mod h1:aUKLBmv5OiWqDzcKExdhdtKsj1FGFxsCpVTYQ8dKI20=
+github.com/rancher/security-scan v0.4.0 h1:UEj2W5TAe0yyc4e1WXa2MIKPoR2Yjm0UmVZ+ivwwztM=
+github.com/rancher/security-scan v0.4.0/go.mod h1:aUKLBmv5OiWqDzcKExdhdtKsj1FGFxsCpVTYQ8dKI20=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=


### PR DESCRIPTION
also downgraded kubectl to v1.29.7
it will get bumped in the upcoming release.