### PR TITLE
[release/v1.3] added gke volumes to security scan config template

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
     <1.21.0: rke2-cis-1.20-profile-permissive
     >=1.21.0: rke2-cis-1.8-profile-permissive
   eks: "eks-profile"
-  gke: "gke-profile"
+  gke: "gke-profile-1.6.0"
   aks: "aks-profile"
   k3s: "k3s-cis-1.8-profile-permissive"
   default: "cis-1.8-profile"

--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -56,6 +56,12 @@ data:
       - hostPath:
           path: /run/log
         name: run-log
+      - hostPath:
+          path: /etc/kubernetes/kubelet
+        name: etc-kubelet
+      - hostPath:
+          path: /var/lib/kubelet
+        name: var-kubelet
       {{- if .isCustomBenchmark }}
       - configMap:
           defaultMode: 420
@@ -131,6 +137,12 @@ data:
         readOnly: true
       - mountPath: /run/log/
         name: run-log
+        readOnly: true
+      - mountPath: /etc/kubernetes/kubelet
+        name: etc-kubelet
+        readOnly: true
+      - mountPath: /var/lib/kubelet
+        name: var-kubelet
         readOnly: true
       {{- if .isCustomBenchmark }}
       - mountPath: /etc/kbs/custombenchmark/cfg


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/48112
also updated default scan profile for gke to gke-profile-1.6.0