### PR TITLE
Update release table with v2.10 branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The current branch strategy for `rancher/cis-operator` is laid out below:
 | Branch                | Tag      |Security-Scan          | Rancher                   |
 |-----------------------|----------|-----------------------|---------------------------|
 | `main`                | `head`   |`main` branch (`head`)`| `main` branch (`head`)    |
+| `release/v1.3`        | `v1.3.x` |`v0.5.x`               | `v2.10.x`                 |
 | `release/v1.2`        | `v1.2.x` |`v0.4.x`               | `v2.9.x`                  |
 | `release/v1.1`        | `v1.1.x` |`v0.3.x`               | `v2.8.x`                  |
 | `master` (deprecated) | `v1.0.x` |`v0.2.x`               | `v2.7.x`,`v2.8.x`,`v2.9.x`|


### PR DESCRIPTION
This PR updates README, to add the following in the release table for `RM v2.10.x` :

- | `release/v1.3`        | `v1.3.x` |`v0.5.x`               | `v2.10.x`                  |