### PR TITLE
[release/v1.1] bump kubectl and security-scan

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-cis-benchmark
 apiVersion: v1
-appVersion: v5.6.0
+appVersion: v5.7.0
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security
 name: rancher-cis-benchmark
-version: 5.6.0
+version: 5.7.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,7 +5,7 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.1.0
+    tag: v1.1.1
   securityScan:
     repository: rancher/security-scan
     tag: v0.3.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ image:
     tag: v1.1.0
   securityScan:
     repository: rancher/security-scan
-    tag: v0.3.0
+    tag: v0.3.1
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.2
@@ -47,7 +47,7 @@ global:
       enabled: false
   kubectl:
     repository: rancher/kubectl
-    tag: v1.28.12
+    tag: v1.28.15
 
 alerts:
   enabled: false

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -4,6 +4,6 @@ GOLANGCI_VERSION = v1.62.0
 K3D_VERSION = v5.7.5
 
 # TODO: Bump aligned with Rancher Manager release line
-KUBECTL_VERSION = 1.28.12
+KUBECTL_VERSION = 1.28.15
 # renovate: datasource=github-release-attachments depName=helm/helm
 HELM_VERSION = v3.16.3


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/48412
- bumped security-scan to v0.3.1 and kubectl to v1.28.15
- bumped cis-operator and upgraded chart version (to be tagged after this PR is merged).