### PR TITLE
[release/v1.2] unrc chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ generate: ## Run code generation logic.
 validate: validate-lint generate validate-dirty ## Run validation checks.
 
 validate-lint: $(GOLANGCI)
-	$(GOLANGCI) run
+	$(GOLANGCI) run --timeout=2m
 
 validate-dirty:
 ifdef DIRTY

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-cis-benchmark
 apiVersion: v1
-appVersion: v6.7.0-rc.2
+appVersion: v6.7.0
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security
 name: rancher-cis-benchmark
-version: 6.7.0-rc.2
+version: 6.7.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.2.5-rc.2
+    tag: v1.2.5
   securityScan:
     repository: rancher/security-scan
-    tag: v0.4.3-rc.2
+    tag: v0.4.3
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.2

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rancher/lasso v0.0.0-20240828170735-d79536cac289
-	github.com/rancher/security-scan v0.4.3-rc.2
+	github.com/rancher/security-scan v0.4.3
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.16

--- a/go.sum
+++ b/go.sum
@@ -1019,8 +1019,8 @@ github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM
 github.com/rancher/kubernetes-provider-detector v0.1.5/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20240828170735-d79536cac289 h1:gbV7qLOcEgyTgep2ocl8FFhfGOUMQuvfV5OIIENHWT4=
 github.com/rancher/lasso v0.0.0-20240828170735-d79536cac289/go.mod h1:Efx/+BbH3ivmnTPLu5cA3Gc9wT5oyGS0LBcqEuYTx+A=
-github.com/rancher/security-scan v0.4.3-rc.2 h1:fbYzfa28ez5U37BJe6Iy5kV9rPH+iwbk638jPcORc08=
-github.com/rancher/security-scan v0.4.3-rc.2/go.mod h1:LS57VSm7BMu+KMB2l/KvVfLD+uuXzgHO76WvAHorQIo=
+github.com/rancher/security-scan v0.4.3 h1:m6OQlM2+sVgbKdnU++m1VWoNpPsVg5vaQSN3hNtPyFY=
+github.com/rancher/security-scan v0.4.3/go.mod h1:LS57VSm7BMu+KMB2l/KvVfLD+uuXzgHO76WvAHorQIo=
 github.com/rancher/wrangler/v3 v3.0.0 h1:IHHCA+vrghJDPxjtLk4fmeSCFhNe9fFzLFj3m2B0YpA=
 github.com/rancher/wrangler/v3 v3.0.0/go.mod h1:Dfckuuq7MJk2JWVBDywRlZXMxEyPxHy4XqGrPEzu5Eg=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,5 +1,5 @@
 # renovate: datasource=github-release-attachments depName=golangci/golangci-lint
-GOLANGCI_VERSION = v1.63.4
+GOLANGCI_VERSION = v1.64.5
 # renovate: datasource=github-release-attachments depName=k3d-io/k3d
 K3D_VERSION = v5.8.1
 


### PR DESCRIPTION
- unrc security-scan and the chart
- bumped golangci lint and updated lint timeout (needed to make the CI pass)