### PR TITLE
[release/v1.3] unrc chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ generate: ## Run code generation logic.
 validate: validate-lint generate validate-dirty ## Run validation checks.
 
 validate-lint: $(GOLANGCI)
-	$(GOLANGCI) run
+	$(GOLANGCI) run --timeout=2m
 
 validate-dirty:
 ifdef DIRTY

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-cis-benchmark
 apiVersion: v1
-appVersion: v7.3.0-rc.2
+appVersion: v7.3.0
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security
 name: rancher-cis-benchmark
-version: 7.3.0-rc.2
+version: 7.3.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.3.6-rc.2
+    tag: v1.3.6
   securityScan:
     repository: rancher/security-scan
-    tag: v0.5.4-rc.2
+    tag: v0.5.4
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.2

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rancher/lasso v0.0.0-20240924233157-8f384efc8813
-	github.com/rancher/security-scan v0.5.4-rc.2
+	github.com/rancher/security-scan v0.5.4
 	github.com/rancher/wrangler/v3 v3.1.0
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM
 github.com/rancher/kubernetes-provider-detector v0.1.5/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20240924233157-8f384efc8813 h1:V/LY8pUHZG9Kc+xEDWDOryOnCU6/Q+Lsr9QQEQnshpU=
 github.com/rancher/lasso v0.0.0-20240924233157-8f384efc8813/go.mod h1:IxgTBO55lziYhTEETyVKiT8/B5Rg92qYiRmcIIYoPgI=
-github.com/rancher/security-scan v0.5.4-rc.2 h1:lfmwbTfMqK7k0+PpxtMNdIStzdIfFr9tl3G8RSndqcI=
-github.com/rancher/security-scan v0.5.4-rc.2/go.mod h1:LS57VSm7BMu+KMB2l/KvVfLD+uuXzgHO76WvAHorQIo=
+github.com/rancher/security-scan v0.5.4 h1:llg69uTonGxShVe7PmhjqJu0g4O0JnJeZ3gyDaGRYwY=
+github.com/rancher/security-scan v0.5.4/go.mod h1:LS57VSm7BMu+KMB2l/KvVfLD+uuXzgHO76WvAHorQIo=
 github.com/rancher/wrangler/v3 v3.1.0 h1:8ETBnQOEcZaR6WBmUSysWW7WnERBOiNTMJr4Dj3UG/s=
 github.com/rancher/wrangler/v3 v3.1.0/go.mod h1:gUPHS1ANs2NyByfeERHwkGiQ1rlIa8BpTJZtNSgMlZw=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,5 +1,5 @@
 # renovate: datasource=github-release-attachments depName=golangci/golangci-lint
-GOLANGCI_VERSION = v1.63.4
+GOLANGCI_VERSION = v1.64.5
 # renovate: datasource=github-release-attachments depName=k3d-io/k3d
 K3D_VERSION = v5.8.1
 


### PR DESCRIPTION
- unrc security-scan and the chart
- bumped golangci lint and updated lint timeout (needed to make the CI pass)