### PR TITLE
[release/v1.4] unrc chart versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version: 'stable'
+        go-version-file: 'go.mod'
     - run: make validate
 
   test:
@@ -38,7 +38,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version: 'stable'
+        go-version-file: 'go.mod'
   
     - run: make test
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-cis-benchmark
 apiVersion: v1
-appVersion: v8.8.0-rc.1
+appVersion: v8.8.0
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security
 name: rancher-cis-benchmark
-version: 8.8.0-rc.1
+version: 8.8.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.4.8-rc.1
+    tag: v1.4.8
   securityScan:
     repository: rancher/security-scan
-    tag: v0.6.8-rc.1
+    tag: v0.6.8
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.3

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rancher/lasso v0.2.1
-	github.com/rancher/security-scan v0.6.8-rc.1
+	github.com/rancher/security-scan v0.6.8
 	github.com/rancher/wrangler/v3 v3.2.0
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM
 github.com/rancher/kubernetes-provider-detector v0.1.5/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.2.1 h1:SZTqMVQn8cAOqvwGBd1/EYOIJ/MGN+UfJrOWvHd4jHU=
 github.com/rancher/lasso v0.2.1/go.mod h1:KSV3jBXfdXqdCuMm2uC8kKB9q/wuDYb3h0eHZoRjShM=
-github.com/rancher/security-scan v0.6.8-rc.1 h1:aZDKFGWCxTppY4/RDmeK8BYjb/n9GWFWtVkAdG63yfA=
-github.com/rancher/security-scan v0.6.8-rc.1/go.mod h1:jzL4hQT6S51yJU5i7yfrwex8XQfv7j7eFux3HLEE48A=
+github.com/rancher/security-scan v0.6.8 h1:7gCRwCWdy8KTyEPUAJv97rRyknHS4aVa+gSlokAAdvQ=
+github.com/rancher/security-scan v0.6.8/go.mod h1:jzL4hQT6S51yJU5i7yfrwex8XQfv7j7eFux3HLEE48A=
 github.com/rancher/wrangler/v3 v3.2.0 h1:fZmhSOczW+pxAhyOaGG+9xbEwETPGA5gbS0x0Im2zWs=
 github.com/rancher/wrangler/v3 v3.2.0/go.mod h1:0C5QyvSrQOff8gQQzpB/L/FF03EQycjR3unSJcKCHno=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=


### PR DESCRIPTION
bump appVersion and version to v8.8.0 and v1.4.8, security-scan dependency to v0.6.8
and updated `go-version: 'stable'`, in `test.yamll` file causing CI failures due to a version mismatch. Using `go-version-file: 'go.mod'` ensures the workflow always uses the exact Go version defined in the project, keeping CI consistent and avoiding build errors.