### PR TITLE
readme: mark as maintenance only and link to compliance-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,33 @@
-# cis-operator [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rancher/cis-operator/badge)](https://scorecard.dev/viewer/?uri=github.com/rancher/cis-operator)
+# cis-operator [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/rancher/cis-operator/badge)](https://securityscorecards.dev/viewer/?uri=github.com/rancher/cis-operator)
 
-The cis-operator enables running CIS benchmark security scans on a Kubernetes cluster and generate compliance reports that can be downloaded.
-Benchmarks tests and the execution logic lives on [rancher/security-scan].
+The cis-operator enables running CIS benchmark security scans on a Kubernetes cluster and generate compliance reports that can be downloaded. Benchmarks tests and the execution logic lives on [rancher/security-scan](https://github.com/rancher/security-scan).
 
-## Building
+> [!IMPORTANT]
+> **This project has been replaced by [rancher/compliance-operator](https://github.com/rancher/compliance-operator).** 
+> It is now in a **Security Maintenance Phase** for Rancher 2.10 and 2.11. No new features will be added.
 
-`make`
+---
 
+## Migration
+For Rancher v2.12.0+, the legacy CIS Benchmark App is replaced by the new **[Rancher Compliance App](https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/compliance-scan-guides)**. Please follow the official guide to migrate your custom profiles:
 
-## Running
-1. Install the custom resource definitions:
-- `kubectl apply -f crds/`
-2. Install the operator
-`./bin/cis-operator`
+👉 **[Migration Guide: CIS Benchmark to Rancher Compliance](https://support.scc.suse.com/s/kb/Migrating-from-Rancher-CIS-Benchmark-to-Rancher-Compliance?language=en_US)**
 
+---
+
+## Support Status
+
+| Branch | Rancher Version | Status | Recommended Action |
+| :--- | :--- | :--- | :--- |
+| **release/v1.4** | v2.11.x | **Security Only** | Move to [Compliance Operator](https://github.com/rancher/compliance-operator) |
+| **release/v1.3** | v2.10.x | **Security Only** | Plan migration for Rancher 2.12+ |
+| **release/v1.2** | v2.9.x | **EOL** | Upgrade to supported version |
+
+### Maintenance Policy
+* **Issues & Feedback:** Direct all new feature requests or general bugs to the [Compliance Operator Issues](https://github.com/rancher/compliance-operator/issues).
+* **Security Patches:** We will continue to review PRs for documented security vulnerabilities (CVEs) on supported 2.10/2.11 lines. All other PRs will be redirected.
+
+---
 
 ## Branches and Releases
 ### General information
@@ -35,13 +49,7 @@ that the Rancher release line it aims to support.
 Active development takes place against `main`. Release branches are only used for
 bug fixes and security-related dependency bumps.
 
-Refer to the [Support Compatibility Matrix](https://www.suse.com/suse-rancher/support-matrix/)
-for official compatibility information.
-
-### How future release branches should be generated
-Follow these guidelines when releasing new branches:
-1. Name convention to be used: `release/v1.x.x`.
-2. Update the [Branch and Releases](https://github.com/rancher/cis-operator#branches-and-releases) table with the new branches and remove the no longer needed branches.
+Refer to the [Support Compatibility Matrix](https://www.suse.com/suse-rancher/support-matrix) for official compatibility information.
 
 ## License
 Copyright (c) 2019 [Rancher Labs, Inc.](http://rancher.com)


### PR DESCRIPTION
- Add maintenance banner
- Redirect new features/issues to rancher/compliance-operator
- Add migration link to official SUSE/Rancher documentation